### PR TITLE
Apply DTO conventions and clean endpoints

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,18 @@
+# Agent Guidelines
+
+## DTO Naming
+- Presentation layer DTOs must use `Request` and `Response` suffixes only.
+  - Organize them under `presentation/dto/request` and `presentation/dto/response` where applicable.
+- Application layer uses `command` for input and `result` for output DTOs.
+- Domain layer keeps entity names without the `Dto` suffix.
+- Use MapStruct interfaces to convert between layers to minimize boilerplate.
+
+## Endpoint Paths
+- Do **not** include version numbers or `/api` prefixes in controller `@RequestMapping` paths.
+  - Base domain already reflects API usage (e.g., `api.zzic.dev`).
+  - API version is supplied via request headers.
+- Example root paths: `/members`, `/challenges`.
+
+## Development
+- After modifying code or documentation run project tests: `./gradlew test`.
+- Keep these guidelines in mind for future contributions.

--- a/src/main/java/point/zzicback/auth/application/TokenService.java
+++ b/src/main/java/point/zzicback/auth/application/TokenService.java
@@ -82,7 +82,7 @@ public class TokenService {
     try {
       jwtDecoder.decode(token);
       return true;
-    } catch (JwtException _) {
+    } catch (JwtException e) {
       return false;
     }
   }

--- a/src/main/java/point/zzicback/auth/presentation/AuthController.java
+++ b/src/main/java/point/zzicback/auth/presentation/AuthController.java
@@ -90,7 +90,7 @@ public class AuthController {
       }
       
       throw new BusinessException("이메일 또는 패스워드가 올바르지 않습니다.");
-    } catch (Exception _) {
+    } catch (Exception e) {
       throw new BusinessException("이메일 또는 패스워드가 올바르지 않습니다.");
     }
   }

--- a/src/main/java/point/zzicback/challenge/application/ChallengeParticipationService.java
+++ b/src/main/java/point/zzicback/challenge/application/ChallengeParticipationService.java
@@ -8,7 +8,7 @@ import point.zzicback.challenge.infrastructure.ChallengeParticipationRepository;
 import point.zzicback.challenge.infrastructure.ChallengeTodoRepository;
 import point.zzicback.common.error.BusinessException;
 import point.zzicback.member.domain.Member;
-import point.zzicback.challenge.application.dto.result.ParticipantDto;
+import point.zzicback.challenge.application.dto.result.ParticipantResult;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.PageImpl;
@@ -55,11 +55,11 @@ public class ChallengeParticipationService {
      * 특정 챌린지의 참여자 목록을 Application DTO로 반환
      */
     @Transactional(readOnly = true)
-    public Page<ParticipantDto> getParticipants(Long challengeId, Pageable pageable) {
+    public Page<ParticipantResult> getParticipants(Long challengeId, Pageable pageable) {
         Challenge challenge = challengeService.findById(challengeId);
-        List<ParticipantDto> participants = challenge.getParticipations().stream()
+        List<ParticipantResult> participants = challenge.getParticipations().stream()
                 .filter(p -> p.getJoinOut() == null)
-                .map(p -> new ParticipantDto(
+                .map(p -> new ParticipantResult(
                         p.getMember().getId(),
                         p.getMember().getEmail(),
                         p.getMember().getNickname(),
@@ -67,7 +67,7 @@ public class ChallengeParticipationService {
                 .toList();
         int start = (int) pageable.getOffset();
         int end = Math.min(start + pageable.getPageSize(), participants.size());
-        List<ParticipantDto> pageList = participants.subList(start, end);
+        List<ParticipantResult> pageList = participants.subList(start, end);
         return new PageImpl<>(pageList, pageable, participants.size());
     }
 

--- a/src/main/java/point/zzicback/challenge/application/ChallengeService.java
+++ b/src/main/java/point/zzicback/challenge/application/ChallengeService.java
@@ -7,7 +7,7 @@ import org.springframework.transaction.annotation.Transactional;
 import point.zzicback.challenge.application.dto.command.CreateChallengeCommand;
 import point.zzicback.challenge.application.dto.command.UpdateChallengeCommand;
 import point.zzicback.challenge.application.dto.result.*;
-import point.zzicback.challenge.application.dto.result.ChallengeJoinedDto;
+import point.zzicback.challenge.application.dto.result.ChallengeJoinedResult;
 import point.zzicback.challenge.domain.Challenge;
 import point.zzicback.challenge.domain.PeriodType;
 import point.zzicback.challenge.infrastructure.*;
@@ -66,7 +66,7 @@ public class ChallengeService {
     }
 
     @Transactional(readOnly = true)
-    public Page<ChallengeListDto> searchChallengesWithFilter(Member member, String keyword, String sort, Boolean join, Pageable pageable) {
+    public Page<ChallengeListResult> searchChallengesWithFilter(Member member, String keyword, String sort, Boolean join, Pageable pageable) {
         Page<Challenge> challengePage;
         if (keyword == null || keyword.trim().isEmpty()) {
             challengePage = "popular".equals(sort)
@@ -83,7 +83,7 @@ public class ChallengeService {
                 .map(participation -> participation.getChallenge().getId())
                 .toList();
         
-        List<ChallengeListDto> filteredChallenges = challengePage.getContent().stream()
+        List<ChallengeListResult> filteredChallenges = challengePage.getContent().stream()
                 .map(challenge -> {
                     boolean isParticipated = participatedChallengeIds.contains(challenge.getId());
                     
@@ -91,7 +91,7 @@ public class ChallengeService {
                             .filter(participation -> participation.getJoinOut() == null)
                             .count();
                     
-                    return new ChallengeListDto(
+                    return new ChallengeListResult(
                             challenge.getId(),
                             challenge.getTitle(),
                             challenge.getDescription(),
@@ -109,7 +109,7 @@ public class ChallengeService {
     }
 
     @Transactional(readOnly = true)
-    public List<ChallengeJoinedDto> getChallengesByMember(Member member) {
+    public List<ChallengeJoinedResult> getChallengesByMember(Member member) {
         List<Challenge> allChallenges = challengeRepository.findAll();
         List<Long> participatedChallengeIds = challengeParticipationRepository.findByMemberAndJoinOutIsNull(member)
                 .stream()
@@ -117,7 +117,7 @@ public class ChallengeService {
                 .toList();
         
         return allChallenges.stream()
-                .map(challenge -> new ChallengeJoinedDto(
+                .map(challenge -> new ChallengeJoinedResult(
                         challenge.getId(),
                         challenge.getTitle(),
                         challenge.getDescription(),
@@ -141,7 +141,7 @@ public class ChallengeService {
     }
 
     @Transactional(readOnly = true)
-    public ChallengeDto getChallengeWithParticipation(Long challengeId, Member member) {
+    public ChallengeResult getChallengeWithParticipation(Long challengeId, Member member) {
         Challenge challenge = challengeRepository.findById(challengeId)
                 .orElseThrow(() -> new EntityNotFoundException("Challenge", challengeId));
         
@@ -165,7 +165,7 @@ public class ChallengeService {
         float successRate = totalParticipantCount > 0 ? 
                 Math.round((float) completedParticipantCount / totalParticipantCount * 100) / 100.0f : 0.0f;
         
-        return new ChallengeDto(
+        return new ChallengeResult(
                 challenge.getId(),
                 challenge.getTitle(),
                 challenge.getDescription(),

--- a/src/main/java/point/zzicback/challenge/application/ChallengeTodoService.java
+++ b/src/main/java/point/zzicback/challenge/application/ChallengeTodoService.java
@@ -7,7 +7,7 @@ import org.springframework.transaction.annotation.Transactional;
 import point.zzicback.challenge.domain.*;
 import point.zzicback.challenge.infrastructure.ChallengeParticipationRepository;
 import point.zzicback.challenge.infrastructure.ChallengeTodoRepository;
-import point.zzicback.challenge.application.dto.result.ChallengeTodoDto;
+import point.zzicback.challenge.application.dto.result.ChallengeTodoResult;
 import point.zzicback.common.error.BusinessException;
 import point.zzicback.common.error.EntityNotFoundException;
 import point.zzicback.member.domain.Member;
@@ -90,7 +90,7 @@ public class ChallengeTodoService {
     }
     
     @Transactional(readOnly = true)
-    public List<ChallengeTodoDto> getAllChallengeTodos(Member member) {
+    public List<ChallengeTodoResult> getAllChallengeTodos(Member member) {
         List<ChallengeParticipation> participations = participationRepository.findByMemberAndJoinOutIsNull(member);
 
         return participations.stream()
@@ -99,17 +99,17 @@ public class ChallengeTodoService {
     }
 
     @Transactional(readOnly = true)
-    public Page<ChallengeTodoDto> getAllChallengeTodos(Member member, Pageable pageable) {
-        List<ChallengeTodoDto> allTodos = getAllChallengeTodos(member);
+    public Page<ChallengeTodoResult> getAllChallengeTodos(Member member, Pageable pageable) {
+        List<ChallengeTodoResult> allTodos = getAllChallengeTodos(member);
         allTodos = applySorting(allTodos, pageable.getSort());
         int start = (int) pageable.getOffset();
         int end = Math.min((start + pageable.getPageSize()), allTodos.size());
-        List<ChallengeTodoDto> pagedTodos = allTodos.subList(start, end);
+        List<ChallengeTodoResult> pagedTodos = allTodos.subList(start, end);
         return new PageImpl<>(pagedTodos, pageable, allTodos.size());
     }
  
     @Transactional(readOnly = true)
-    public List<ChallengeTodoDto> getUncompletedChallengeTodos(Member member) {
+    public List<ChallengeTodoResult> getUncompletedChallengeTodos(Member member) {
         List<ChallengeParticipation> participations = participationRepository.findByMemberAndJoinOutIsNull(member);
 
         return participations.stream()
@@ -118,17 +118,17 @@ public class ChallengeTodoService {
     }
 
     @Transactional(readOnly = true)
-    public Page<ChallengeTodoDto> getUncompletedChallengeTodos(Member member, Pageable pageable) {
-        List<ChallengeTodoDto> allTodos = getUncompletedChallengeTodos(member);
+    public Page<ChallengeTodoResult> getUncompletedChallengeTodos(Member member, Pageable pageable) {
+        List<ChallengeTodoResult> allTodos = getUncompletedChallengeTodos(member);
         allTodos = applySorting(allTodos, pageable.getSort());
         int start = (int) pageable.getOffset();
         int end = Math.min((start + pageable.getPageSize()), allTodos.size());
-        List<ChallengeTodoDto> pagedTodos = allTodos.subList(start, end);
+        List<ChallengeTodoResult> pagedTodos = allTodos.subList(start, end);
         return new PageImpl<>(pagedTodos, pageable, allTodos.size());
     }
 
     @Transactional(readOnly = true)
-    public List<ChallengeTodoDto> getCompletedChallengeTodos(Member member) {
+    public List<ChallengeTodoResult> getCompletedChallengeTodos(Member member) {
         List<ChallengeParticipation> participations = participationRepository.findByMemberAndJoinOutIsNull(member);
 
         return participations.stream()
@@ -137,16 +137,16 @@ public class ChallengeTodoService {
     }
 
     @Transactional(readOnly = true)
-    public Page<ChallengeTodoDto> getCompletedChallengeTodos(Member member, Pageable pageable) {
-        List<ChallengeTodoDto> allTodos = getCompletedChallengeTodos(member);
+    public Page<ChallengeTodoResult> getCompletedChallengeTodos(Member member, Pageable pageable) {
+        List<ChallengeTodoResult> allTodos = getCompletedChallengeTodos(member);
         allTodos = applySorting(allTodos, pageable.getSort());
         int start = (int) pageable.getOffset();
         int end = Math.min((start + pageable.getPageSize()), allTodos.size());
-        List<ChallengeTodoDto> pagedTodos = allTodos.subList(start, end);
+        List<ChallengeTodoResult> pagedTodos = allTodos.subList(start, end);
         return new PageImpl<>(pagedTodos, pageable, allTodos.size());
     }
 
-    private Stream<ChallengeTodoDto> createChallengeTodoStream(ChallengeParticipation participation) {
+    private Stream<ChallengeTodoResult> createChallengeTodoStream(ChallengeParticipation participation) {
         LocalDate currentDate = LocalDate.now();
         var virtualTodo = createVirtualChallengeTodo(participation, currentDate);
         PeriodType periodType = participation.getChallenge().getPeriodType();
@@ -168,13 +168,13 @@ public class ChallengeTodoService {
             if (!todo.isInPeriod(periodType, currentDate)) {
                 return Stream.empty();
             }
-            return Stream.of(ChallengeTodoDto.from(todo));
+            return Stream.of(ChallengeTodoResult.from(todo));
         } else {
-            return Stream.of(ChallengeTodoDto.from(virtualTodo));
+            return Stream.of(ChallengeTodoResult.from(virtualTodo));
         }
     }
 
-    private Stream<ChallengeTodoDto> createUncompletedChallengeTodoStream(ChallengeParticipation participation) {
+    private Stream<ChallengeTodoResult> createUncompletedChallengeTodoStream(ChallengeParticipation participation) {
         try {
             LocalDate currentDate = LocalDate.now();
             var virtualTodo = createVirtualChallengeTodo(participation, currentDate);
@@ -198,19 +198,19 @@ public class ChallengeTodoService {
                     return Stream.empty();
                 }
                 if (!todo.isCompleted()) {
-                    return Stream.of(ChallengeTodoDto.from(todo));
+                    return Stream.of(ChallengeTodoResult.from(todo));
                 } else {
                     return Stream.empty();
                 }
             } else {
-                return Stream.of(ChallengeTodoDto.from(virtualTodo));
+                return Stream.of(ChallengeTodoResult.from(virtualTodo));
             }
         } catch (Exception e) {
             return Stream.empty();
         }
     }
 
-    private Stream<ChallengeTodoDto> createCompletedChallengeTodoStream(ChallengeParticipation participation) {
+    private Stream<ChallengeTodoResult> createCompletedChallengeTodoStream(ChallengeParticipation participation) {
         try {
             LocalDate currentDate = LocalDate.now();
             var virtualTodo = createVirtualChallengeTodo(participation, currentDate);
@@ -225,7 +225,7 @@ public class ChallengeTodoService {
             
             return challengeTodoRepository.findByChallengeParticipation(participation)
                     .filter(ChallengeTodo::isCompleted)
-                    .map(ChallengeTodoDto::from)
+                    .map(ChallengeTodoResult::from)
                     .map(Stream::of)
                     .orElse(Stream.empty());
         } catch (Exception e) {
@@ -270,13 +270,13 @@ public class ChallengeTodoService {
         completeChallenge(participation, currentDate);
     }
 
-    private List<ChallengeTodoDto> applySorting(List<ChallengeTodoDto> todos, Sort sort) {
+    private List<ChallengeTodoResult> applySorting(List<ChallengeTodoResult> todos, Sort sort) {
         if (sort.isEmpty()) return todos;
         
-        Comparator<ChallengeTodoDto> finalComparator = null;
+        Comparator<ChallengeTodoResult> finalComparator = null;
         
         for (Sort.Order order : sort) {
-            Comparator<ChallengeTodoDto> currentComparator = getComparatorByProperty(order.getProperty());
+            Comparator<ChallengeTodoResult> currentComparator = getComparatorByProperty(order.getProperty());
             
             if (order.isDescending()) {
                 currentComparator = currentComparator.reversed();
@@ -288,17 +288,17 @@ public class ChallengeTodoService {
         }
         
         return todos.stream()
-                .sorted(finalComparator != null ? finalComparator : Comparator.comparing(ChallengeTodoDto::id, Comparator.nullsLast(Comparator.naturalOrder())))
+                .sorted(finalComparator != null ? finalComparator : Comparator.comparing(ChallengeTodoResult::id, Comparator.nullsLast(Comparator.naturalOrder())))
                 .toList();
     }
 
-    private Comparator<ChallengeTodoDto> getComparatorByProperty(String property) {
+    private Comparator<ChallengeTodoResult> getComparatorByProperty(String property) {
         return switch (property) {
-            case "challengeTitle" -> Comparator.comparing(ChallengeTodoDto::challengeTitle, Comparator.nullsLast(String::compareTo));
-            case "startDate" -> Comparator.comparing(ChallengeTodoDto::startDate, Comparator.nullsLast(Comparator.naturalOrder()));  
-            case "endDate" -> Comparator.comparing(ChallengeTodoDto::endDate, Comparator.nullsLast(Comparator.naturalOrder()));
-            case "periodType" -> Comparator.comparing(ChallengeTodoDto::periodType, Comparator.nullsLast(Comparator.naturalOrder()));
-            default -> Comparator.comparing(ChallengeTodoDto::id, Comparator.nullsLast(Comparator.naturalOrder()));
+            case "challengeTitle" -> Comparator.comparing(ChallengeTodoResult::challengeTitle, Comparator.nullsLast(String::compareTo));
+            case "startDate" -> Comparator.comparing(ChallengeTodoResult::startDate, Comparator.nullsLast(Comparator.naturalOrder()));  
+            case "endDate" -> Comparator.comparing(ChallengeTodoResult::endDate, Comparator.nullsLast(Comparator.naturalOrder()));
+            case "periodType" -> Comparator.comparing(ChallengeTodoResult::periodType, Comparator.nullsLast(Comparator.naturalOrder()));
+            default -> Comparator.comparing(ChallengeTodoResult::id, Comparator.nullsLast(Comparator.naturalOrder()));
         };
     }
 

--- a/src/main/java/point/zzicback/challenge/application/dto/result/ChallengeDetailResult.java
+++ b/src/main/java/point/zzicback/challenge/application/dto/result/ChallengeDetailResult.java
@@ -2,14 +2,15 @@ package point.zzicback.challenge.application.dto.result;
 
 import point.zzicback.challenge.domain.PeriodType;
 import java.time.LocalDate;
+import java.util.List;
 
-public record ChallengeJoinedDto(
+public record ChallengeDetailResult(
         Long id,
         String title,
         String description,
         LocalDate startDate,
         LocalDate endDate,
         PeriodType periodType,
-        boolean participationStatus
+        List<ParticipantResult> participants
 ) {
 }

--- a/src/main/java/point/zzicback/challenge/application/dto/result/ChallengeJoinedResult.java
+++ b/src/main/java/point/zzicback/challenge/application/dto/result/ChallengeJoinedResult.java
@@ -2,15 +2,14 @@ package point.zzicback.challenge.application.dto.result;
 
 import point.zzicback.challenge.domain.PeriodType;
 import java.time.LocalDate;
-import java.util.List;
 
-public record ChallengeDetailDto(
+public record ChallengeJoinedResult(
         Long id,
         String title,
         String description,
         LocalDate startDate,
         LocalDate endDate,
         PeriodType periodType,
-        List<ParticipantDto> participants
+        boolean participationStatus
 ) {
 }

--- a/src/main/java/point/zzicback/challenge/application/dto/result/ChallengeListResult.java
+++ b/src/main/java/point/zzicback/challenge/application/dto/result/ChallengeListResult.java
@@ -3,7 +3,7 @@ package point.zzicback.challenge.application.dto.result;
 import point.zzicback.challenge.domain.PeriodType;
 import java.time.LocalDate;
 
-public record ChallengeListDto(
+public record ChallengeListResult(
         Long id,
         String title,
         String description,
@@ -11,6 +11,6 @@ public record ChallengeListDto(
         LocalDate endDate,
         PeriodType periodType,
         Boolean participationStatus,
-        Integer participantCount
+        Integer activeParticipantCount
 ) {
 }

--- a/src/main/java/point/zzicback/challenge/application/dto/result/ChallengeParticipantsResult.java
+++ b/src/main/java/point/zzicback/challenge/application/dto/result/ChallengeParticipantsResult.java
@@ -2,9 +2,9 @@ package point.zzicback.challenge.application.dto.result;
 
 import java.util.List;
 
-public record ChallengeParticipantsDto(
+public record ChallengeParticipantsResult(
         Long challengeId,
         String title,
-        List<ParticipantDto> participants
+        List<ParticipantResult> participants
 ) {
 }

--- a/src/main/java/point/zzicback/challenge/application/dto/result/ChallengeResult.java
+++ b/src/main/java/point/zzicback/challenge/application/dto/result/ChallengeResult.java
@@ -5,7 +5,7 @@ import point.zzicback.challenge.domain.PeriodType;
 import java.time.LocalDate;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public record ChallengeDto(
+public record ChallengeResult(
         Long id,
         String title,
         String description,
@@ -13,7 +13,7 @@ public record ChallengeDto(
         LocalDate endDate,
         PeriodType periodType,
         Boolean participationStatus,
-        Integer participantCount,
+        Integer activeParticipantCount,
         Float successRate
 ) {
 }

--- a/src/main/java/point/zzicback/challenge/application/dto/result/ChallengeTodoResult.java
+++ b/src/main/java/point/zzicback/challenge/application/dto/result/ChallengeTodoResult.java
@@ -3,7 +3,7 @@ package point.zzicback.challenge.application.dto.result;
 import point.zzicback.challenge.domain.PeriodType;
 import java.time.LocalDate;
 
-public record ChallengeTodoDto(
+public record ChallengeTodoResult(
         Long id,
         String challengeTitle,
         String challengeDescription,
@@ -13,7 +13,7 @@ public record ChallengeTodoDto(
         Boolean isPersisted,
         PeriodType periodType
 ) {
-    public static ChallengeTodoDto from(point.zzicback.challenge.domain.ChallengeTodo challengeTodo) {
+    public static ChallengeTodoResult from(point.zzicback.challenge.domain.ChallengeTodo challengeTodo) {
         // Null 체크로 NullPointerException 방지
         if (challengeTodo == null) {
             throw new IllegalArgumentException("ChallengeTodo cannot be null");
@@ -31,7 +31,7 @@ public record ChallengeTodoDto(
         
         var period = challengeTodo.getPeriod();
         
-        return new ChallengeTodoDto(
+        return new ChallengeTodoResult(
                 challengeTodo.getId(),
                 challenge.getTitle(),
                 challenge.getDescription(),

--- a/src/main/java/point/zzicback/challenge/application/dto/result/ParticipantResult.java
+++ b/src/main/java/point/zzicback/challenge/application/dto/result/ParticipantResult.java
@@ -3,7 +3,7 @@ package point.zzicback.challenge.application.dto.result;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
-public record ParticipantDto(
+public record ParticipantResult(
         UUID id,
         String email,
         String nickname,

--- a/src/main/java/point/zzicback/challenge/presentation/ChallengeController.java
+++ b/src/main/java/point/zzicback/challenge/presentation/ChallengeController.java
@@ -29,10 +29,10 @@ import point.zzicback.challenge.application.ChallengeService;
 import point.zzicback.challenge.application.ChallengeParticipationService;
 import point.zzicback.challenge.application.dto.command.CreateChallengeCommand;
 import point.zzicback.challenge.application.dto.command.UpdateChallengeCommand;
-import point.zzicback.challenge.application.dto.result.ChallengeDto;
-import point.zzicback.challenge.application.dto.result.ChallengeListDto;
-import point.zzicback.challenge.application.dto.result.ChallengeDetailDto;
-import point.zzicback.challenge.application.dto.result.ParticipantDto;
+import point.zzicback.challenge.application.dto.result.ChallengeResult;
+import point.zzicback.challenge.application.dto.result.ChallengeListResult;
+import point.zzicback.challenge.application.dto.result.ChallengeDetailResult;
+import point.zzicback.challenge.application.dto.result.ParticipantResult;
 import point.zzicback.challenge.presentation.dto.CreateChallengeRequest;
 import point.zzicback.challenge.presentation.dto.CreateChallengeResponse;
 import point.zzicback.challenge.presentation.dto.ParticipantResponse;
@@ -50,7 +50,7 @@ import java.time.LocalDate;
 @Tag(name = "챌린지", description = "챌린지 관련 API")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/challenges")
+@RequestMapping("/challenges")
 public class ChallengeController {
     
     private final ChallengeService challengeService;
@@ -84,7 +84,7 @@ public class ChallengeController {
             @RequestParam(required = false) String search,
             @RequestParam(required = false) Boolean join) {
         Pageable pageable = createPageable(page, size, sort);
-        Page<ChallengeListDto> pageDto;
+        Page<ChallengeListResult> pageDto;
         if (principal != null) {
             Member member = memberService.findVerifiedMember(principal.id());
             pageDto = challengeService.searchChallengesWithFilter(member, search, sort, join, pageable);
@@ -108,7 +108,7 @@ public class ChallengeController {
             var dto = challengeService.getChallengeWithParticipation(challengeId, member);
             response = challengePresentationMapper.toResponse(dto);
         } else {
-            var dto = challengePresentationMapper.toDto(
+            var dto = challengePresentationMapper.toResult(
                     challengeService.getChallenge(challengeId)
             );
             response = challengePresentationMapper.toResponse(dto);
@@ -145,7 +145,7 @@ public class ChallengeController {
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size) {
         Pageable pageable = PageRequest.of(page, size);
-        Page<ParticipantDto> pageDto = participationService.getParticipants(challengeId, pageable);
+        Page<ParticipantResult> pageDto = participationService.getParticipants(challengeId, pageable);
         return pageDto.map(challengePresentationMapper::toResponse);
     }
 
@@ -158,7 +158,7 @@ public class ChallengeController {
             @AuthenticationPrincipal MemberPrincipal principal) {
         Member member = memberService.findVerifiedMember(principal.id());
         var participation = participationService.joinChallenge(challengeId, member);
-        var dto = challengePresentationMapper.toParticipantDto(participation);
+        var dto = challengePresentationMapper.toParticipantResult(participation);
         return challengePresentationMapper.toResponse(dto);
     }
 

--- a/src/main/java/point/zzicback/challenge/presentation/mapper/ChallengePresentationMapper.java
+++ b/src/main/java/point/zzicback/challenge/presentation/mapper/ChallengePresentationMapper.java
@@ -4,9 +4,9 @@ import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import point.zzicback.challenge.application.dto.command.CreateChallengeCommand;
 import point.zzicback.challenge.application.dto.command.UpdateChallengeCommand;
-import point.zzicback.challenge.application.dto.result.ChallengeListDto;
-import point.zzicback.challenge.application.dto.result.ChallengeDto;
-import point.zzicback.challenge.application.dto.result.ParticipantDto;
+import point.zzicback.challenge.application.dto.result.ChallengeListResult;
+import point.zzicback.challenge.application.dto.result.ChallengeResult;
+import point.zzicback.challenge.application.dto.result.ParticipantResult;
 import point.zzicback.challenge.domain.Challenge;
 import point.zzicback.challenge.domain.ChallengeParticipation;
 import point.zzicback.challenge.domain.PeriodType;
@@ -22,58 +22,20 @@ import java.util.List;
 public interface ChallengePresentationMapper {
 
     /** Presentation 레이어 요청 DTO -> Application Command 변환 */
-    default CreateChallengeCommand toCommand(CreateChallengeRequest request) {
-        if (request == null) return null;
-        return new CreateChallengeCommand(
-            request.title(),
-            request.description(),
-            request.periodType()
-        );
-    }
+    CreateChallengeCommand toCommand(CreateChallengeRequest request);
 
-    default UpdateChallengeCommand toCommand(UpdateChallengeRequest request) {
-        if (request == null) return null;
-        return new UpdateChallengeCommand(
-            request.title(),
-            request.description(),
-            request.periodType()
-        );
-    }
+    /** Presentation 레이어 요청 DTO -> Application Command 변환 */
+    UpdateChallengeCommand toCommand(UpdateChallengeRequest request);
 
-    /**
-     * Domain Challenge -> Application ChallengeListDto -> Presentation ChallengeResponse
-     */
-    /** Presentation 응답 DTO (챌린지 요약) 생성 */
-    default ChallengeResponse toResponse(ChallengeListDto dto) {
-        if (dto == null) return null;
-        return new ChallengeResponse(
-            dto.id(), dto.title(), dto.description(),
-            dto.startDate(), dto.endDate(), dto.periodType(),
-            dto.participationStatus(), dto.activeParticipantCount()
-        );
-    }
+    /** Application 결과 DTO -> Presentation 응답 변환 */
+    ChallengeResponse toResponse(ChallengeListResult dto);
 
-    /**
-     * Domain Challenge -> Application ChallengeDto -> Presentation ChallengeDetailResponse
-     */
-    /** Presentation 응답 DTO (챌린지 상세) 생성 */
-    default ChallengeDetailResponse toResponse(ChallengeDto dto) {
-        if (dto == null) return null;
-        List<ParticipantResponse> resp = dto.participantDtos().stream()
-            .map(this::toResponse)
-            .toList();
-        return new ChallengeDetailResponse(
-            dto.id(), dto.title(), dto.description(),
-            dto.startDate(), dto.endDate(), dto.periodType(),
-            dto.participationStatus(), dto.activeParticipantCount(),
-            dto.successRate(), resp
-        );
+    /** Application 상세 결과 DTO -> Presentation 응답 변환 */
+    ChallengeDetailResponse toResponse(ChallengeResult dto);
 
-    }
-
-    default ChallengeDto toDto(Challenge challenge) {
+    default ChallengeResult toResult(Challenge challenge) {
         if (challenge == null) return null;
-        return new ChallengeDto(
+        return new ChallengeResult(
                 challenge.getId(),
                 challenge.getTitle(),
                 challenge.getDescription(),
@@ -92,20 +54,20 @@ public interface ChallengePresentationMapper {
     @Mapping(target = "email", source = "member.email")
     @Mapping(target = "nickname", source = "member.nickname")
     @Mapping(target = "joinedAt", source = "joinedAt")
-    ParticipantDto toParticipantDto(ChallengeParticipation participation);
+    ParticipantResult toParticipantResult(ChallengeParticipation participation);
 
     /** Application DTO -> Presentation 레이어 응답 DTO 변환 */
-    ParticipantResponse toResponse(ParticipantDto dto);
+    ParticipantResponse toResponse(ParticipantResult dto);
 
-    default ChallengeDetailDto toDetailDto(Challenge challenge) {
+    default ChallengeDetailResult toDetailResult(Challenge challenge) {
         if (challenge == null) return null;
         
-        List<ParticipantDto> activeParticipants = challenge.getParticipations().stream()
+        List<ParticipantResult> activeParticipants = challenge.getParticipations().stream()
                 .filter(participation -> participation.getJoinOut() == null)
-                .map(this::toParticipantDto)
+                .map(this::toParticipantResult)
                 .toList();
         
-        return new ChallengeDetailDto(
+        return new ChallengeDetailResult(
                 challenge.getId(),
                 challenge.getTitle(),
                 challenge.getDescription(),

--- a/src/main/java/point/zzicback/challenge/presentation/mapper/ChallengeTodoPresentationMapper.java
+++ b/src/main/java/point/zzicback/challenge/presentation/mapper/ChallengeTodoPresentationMapper.java
@@ -1,11 +1,11 @@
 package point.zzicback.challenge.presentation.mapper;
 
 import org.mapstruct.Mapper;
-import point.zzicback.challenge.application.dto.result.ChallengeTodoDto;
+import point.zzicback.challenge.application.dto.result.ChallengeTodoResult;
 import point.zzicback.challenge.presentation.dto.ChallengeTodoResponse;
 
 @Mapper(componentModel = "spring")
 public interface ChallengeTodoPresentationMapper {
     
-    ChallengeTodoResponse toResponse(ChallengeTodoDto challengeTodoDto);
+    ChallengeTodoResponse toResponse(ChallengeTodoResult challengeTodoDto);
 }

--- a/src/main/java/point/zzicback/member/application/MemberService.java
+++ b/src/main/java/point/zzicback/member/application/MemberService.java
@@ -11,7 +11,7 @@ import point.zzicback.member.infrastructure.persistence.JpaMemberRepository;
 import java.util.*;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import point.zzicback.member.application.dto.result.MemberDto;
+import point.zzicback.member.application.dto.result.MemberResult;
 
 @Service
 @RequiredArgsConstructor
@@ -64,14 +64,14 @@ public class MemberService {
   }
 
   @Transactional(readOnly = true)
-  public Page<MemberDto> getMembers(Pageable pageable) {
+  public Page<MemberResult> getMembers(Pageable pageable) {
     return memberRepository.findAll(pageable)
-            .map(member -> new MemberDto(member.getId(), member.getEmail(), member.getNickname()));
+            .map(member -> new MemberResult(member.getId(), member.getEmail(), member.getNickname()));
   }
 
   @Transactional(readOnly = true)
-  public MemberDto getMember(UUID memberId) {
+  public MemberResult getMember(UUID memberId) {
     var member = findByIdOrThrow(memberId);
-    return new MemberDto(member.getId(), member.getEmail(), member.getNickname());
+    return new MemberResult(member.getId(), member.getEmail(), member.getNickname());
   }
 }

--- a/src/main/java/point/zzicback/member/application/dto/result/MemberResult.java
+++ b/src/main/java/point/zzicback/member/application/dto/result/MemberResult.java
@@ -5,7 +5,7 @@ import java.util.UUID;
 /**
  * 회원 정보 조회 결과 DTO
  */
-public record MemberDto(
+public record MemberResult(
         UUID id,
         String email,
         String nickname

--- a/src/main/java/point/zzicback/member/presentation/MemberController.java
+++ b/src/main/java/point/zzicback/member/presentation/MemberController.java
@@ -13,7 +13,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import point.zzicback.member.application.MemberService;
 import point.zzicback.member.application.dto.command.UpdateMemberCommand;
-import point.zzicback.member.application.dto.result.MemberDto;
+import point.zzicback.member.application.dto.result.MemberResult;
 import point.zzicback.member.presentation.dto.request.UpdateMemberRequest;
 import point.zzicback.member.presentation.dto.response.MemberResponse;
 import point.zzicback.member.presentation.mapper.MemberPresentationMapper;
@@ -26,7 +26,7 @@ import java.util.UUID;
 @Tag(name = "멤버", description = "회원 관련 API")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/members")
+@RequestMapping("/members")
 public class MemberController {
 
     private final MemberService memberService;
@@ -54,7 +54,7 @@ public class MemberController {
     @ApiResponse(responseCode = "404", description = "회원이 존재하지 않습니다.")
     @GetMapping("/{memberId}")
     public MemberResponse getMember(@PathVariable UUID memberId) {
-        MemberDto dto = memberService.getMember(memberId);
+        MemberResult dto = memberService.getMember(memberId);
         return mapper.toResponse(dto);
     }
 

--- a/src/main/java/point/zzicback/member/presentation/mapper/MemberPresentationMapper.java
+++ b/src/main/java/point/zzicback/member/presentation/mapper/MemberPresentationMapper.java
@@ -2,7 +2,7 @@ package point.zzicback.member.presentation.mapper;
 
 import org.mapstruct.Mapper;
 import point.zzicback.member.application.dto.command.UpdateMemberCommand;
-import point.zzicback.member.application.dto.result.MemberDto;
+import point.zzicback.member.application.dto.result.MemberResult;
 import point.zzicback.member.domain.Member;
 import point.zzicback.member.presentation.dto.request.UpdateMemberRequest;
 import point.zzicback.member.presentation.dto.response.MemberResponse;
@@ -21,9 +21,9 @@ public interface MemberPresentationMapper {
     @Mapping(target = "nickname", source = "request.nickname")
     UpdateMemberCommand toCommand(UUID memberId, UpdateMemberRequest request);
 
-    /** Domain Member -> Application MemberDto 변환 */
-    MemberDto toDto(Member member);
+    /** Domain Member -> Application MemberResult 변환 */
+    MemberResult toResult(Member member);
 
-    /** Application MemberDto -> Presentation Response DTO 변환 */
-    MemberResponse toResponse(MemberDto dto);
+    /** Application MemberResult -> Presentation Response DTO 변환 */
+    MemberResponse toResponse(MemberResult dto);
 }


### PR DESCRIPTION
## Summary
- document DTO and endpoint guidelines
- rename DTO classes to *Result and update mappers
- simplify `ChallengePresentationMapper` with MapStruct
- drop `/api/v1` from controller base paths
- fix compilation issues from preview feature usage

## Testing
- `./gradlew test` *(fails: Task :compileJava FAILED)*

------
https://chatgpt.com/codex/tasks/task_e_684f0085550c832db547f79e9d76431e