### PR TITLE
Add hideStatusIds filter to todos

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ docker-compose -f docker-compose.local.yml down -v
 - `page`: 페이지 번호 (기본값: 0)
 - `size`: 페이지 크기 (기본값: 10)
 - `sort`: 정렬 방식 (기본값: "id,desc")
+- `hideStatusIds`: 숨길 상태 ID 목록 (예: `1,2`)
 
 ### 챌린지 관리
 | HTTP Method | Endpoint | 설명 | 요청 Body | 응답 Body | 상태 코드 |

--- a/src/main/java/point/zzicback/todo/application/TodoService.java
+++ b/src/main/java/point/zzicback/todo/application/TodoService.java
@@ -35,18 +35,23 @@ public class TodoService {
     
     if (hasFilters) {
       todoPage = todoRepository.findByFilters(
-          query.memberId(), 
-          query.statusId(), 
-          query.categoryId(), 
-          query.priorityId(), 
-          query.keyword(), 
+          query.memberId(),
+          query.statusId(),
+          query.categoryId(),
+          query.priorityId(),
+          query.keyword(),
           query.pageable()
       );
     } else {
       todoPage = todoRepository.findByMemberId(query.memberId(), query.pageable());
     }
-    
-    return todoPage.map(this::toTodoResult);
+
+    List<TodoResult> results = todoPage.getContent().stream()
+            .filter(todo -> query.hideStatusIds() == null || !query.hideStatusIds().contains(todo.getActualStatus()))
+            .map(this::toTodoResult)
+            .toList();
+
+    return new PageImpl<>(results, todoPage.getPageable(), results.size());
   }
 
   public TodoResult getTodo(TodoQuery query) {

--- a/src/main/java/point/zzicback/todo/application/dto/query/TodoListQuery.java
+++ b/src/main/java/point/zzicback/todo/application/dto/query/TodoListQuery.java
@@ -4,28 +4,38 @@ import org.springframework.data.domain.Pageable;
 
 import java.util.UUID;
 
-public record TodoListQuery(UUID memberId, Boolean done, Integer statusId, Long categoryId, Integer priorityId, String keyword, Pageable pageable) {
+import java.util.List;
+
+public record TodoListQuery(UUID memberId, Boolean done, Integer statusId, Long categoryId,
+                            Integer priorityId, String keyword, List<Integer> hideStatusIds,
+                            Pageable pageable) {
   public static TodoListQuery of(UUID memberId, Boolean done, Pageable pageable) {
-    return new TodoListQuery(memberId, done, null, null, null, null, pageable);
+    return new TodoListQuery(memberId, done, null, null, null, null, null, pageable);
   }
   
   public static TodoListQuery of(UUID memberId, Integer statusId, Pageable pageable) {
-    return new TodoListQuery(memberId, null, statusId, null, null, null, pageable);
+    return new TodoListQuery(memberId, null, statusId, null, null, null, null, pageable);
   }
   
   public static TodoListQuery of(UUID memberId, Integer statusId, String keyword, Pageable pageable) {
-    return new TodoListQuery(memberId, null, statusId, null, null, keyword, pageable);
+    return new TodoListQuery(memberId, null, statusId, null, null, keyword, null, pageable);
   }
   
   public static TodoListQuery of(UUID memberId, String keyword, Pageable pageable) {
-    return new TodoListQuery(memberId, null, null, null, null, keyword, pageable);
+    return new TodoListQuery(memberId, null, null, null, null, keyword, null, pageable);
   }
   
   public static TodoListQuery of(UUID memberId, Integer statusId, Long categoryId, Integer priorityId, String keyword, Pageable pageable) {
-    return new TodoListQuery(memberId, null, statusId, categoryId, priorityId, keyword, pageable);
+    return new TodoListQuery(memberId, null, statusId, categoryId, priorityId, keyword, null, pageable);
+  }
+
+  public static TodoListQuery of(UUID memberId, Integer statusId, Long categoryId,
+                                 Integer priorityId, String keyword, List<Integer> hideStatusIds,
+                                 Pageable pageable) {
+    return new TodoListQuery(memberId, null, statusId, categoryId, priorityId, keyword, hideStatusIds, pageable);
   }
   
   public static TodoListQuery ofAll(UUID memberId, Pageable pageable) {
-    return new TodoListQuery(memberId, null, null, null, null, null, pageable);
+    return new TodoListQuery(memberId, null, null, null, null, null, null, pageable);
   }
 }

--- a/src/main/java/point/zzicback/todo/presentation/TodoController.java
+++ b/src/main/java/point/zzicback/todo/presentation/TodoController.java
@@ -14,6 +14,8 @@ import point.zzicback.todo.application.dto.query.*;
 import point.zzicback.todo.presentation.dto.*;
 import point.zzicback.todo.presentation.mapper.TodoPresentationMapper;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("/todos")
 @RequiredArgsConstructor
@@ -40,13 +42,16 @@ public class TodoController {
                      example = "1")
           Integer priorityId,
           @RequestParam(required = false)
-          @Parameter(description = "검색 키워드 (제목, 설명, 태그에서 검색)", 
+          @Parameter(description = "검색 키워드 (제목, 설명, 태그에서 검색)",
                      example = "영어")
           String keyword,
-          @RequestParam(defaultValue = "0") int page, 
+          @RequestParam(required = false)
+          @Parameter(description = "숨길 상태 ID 목록", example = "1,2")
+          List<Integer> hideStatusIds,
+          @RequestParam(defaultValue = "0") int page,
           @RequestParam(defaultValue = "10") int size) {
     Pageable pageable = PageRequest.of(page, size);
-    TodoListQuery query = TodoListQuery.of(principal.id(), statusId, categoryId, priorityId, keyword, pageable);
+    TodoListQuery query = TodoListQuery.of(principal.id(), statusId, categoryId, priorityId, keyword, hideStatusIds, pageable);
     return todoService.getTodoList(query).map(todoPresentationMapper::toResponse);
   }
 


### PR DESCRIPTION
## Summary
- support hiding todo statuses with `hideStatusIds` query parameter
- document the new parameter in the README

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_6856be3ddd6c832da917b6806e4d7ce1