### PR TITLE
Add date range filtering for todos

### DIFF
--- a/src/main/java/point/zzicback/todo/application/dto/command/CreateTodoCommand.java
+++ b/src/main/java/point/zzicback/todo/application/dto/command/CreateTodoCommand.java
@@ -3,7 +3,7 @@ package point.zzicback.todo.application.dto.command;
 import jakarta.validation.constraints.*;
 import point.zzicback.todo.domain.*;
 
-import java.time.LocalDate;
+import java.time.Instant;
 import java.util.Set;
 import java.util.UUID;
 
@@ -13,7 +13,7 @@ public record CreateTodoCommand(
         @Size(max = 1000) String description,
         Integer priorityId,
         Long categoryId,
-        LocalDate dueDate,
+        Instant dueDate,
         RepeatType repeatType,
         Set<String> tags
 ) {

--- a/src/main/java/point/zzicback/todo/application/dto/command/UpdateTodoCommand.java
+++ b/src/main/java/point/zzicback/todo/application/dto/command/UpdateTodoCommand.java
@@ -3,7 +3,7 @@ package point.zzicback.todo.application.dto.command;
 import jakarta.validation.constraints.*;
 import point.zzicback.todo.domain.RepeatType;
 
-import java.time.LocalDate;
+import java.time.Instant;
 import java.util.Set;
 import java.util.UUID;
 
@@ -15,7 +15,7 @@ public record UpdateTodoCommand(
         Integer statusId,
         Integer priorityId,
         Long categoryId,
-        LocalDate dueDate,
+        Instant dueDate,
         RepeatType repeatType,
         Set<String> tags
 ) {

--- a/src/main/java/point/zzicback/todo/application/dto/query/TodoListQuery.java
+++ b/src/main/java/point/zzicback/todo/application/dto/query/TodoListQuery.java
@@ -2,40 +2,49 @@ package point.zzicback.todo.application.dto.query;
 
 import org.springframework.data.domain.Pageable;
 
-import java.util.UUID;
-
+import java.time.Instant;
 import java.util.List;
+import java.util.UUID;
 
 public record TodoListQuery(UUID memberId, Boolean done, Integer statusId, Long categoryId,
                             Integer priorityId, String keyword, List<Integer> hideStatusIds,
+                            Instant startDate, Instant endDate,
                             Pageable pageable) {
   public static TodoListQuery of(UUID memberId, Boolean done, Pageable pageable) {
-    return new TodoListQuery(memberId, done, null, null, null, null, null, pageable);
+    return new TodoListQuery(memberId, done, null, null, null, null, null, null, null, pageable);
   }
   
   public static TodoListQuery of(UUID memberId, Integer statusId, Pageable pageable) {
-    return new TodoListQuery(memberId, null, statusId, null, null, null, null, pageable);
+    return new TodoListQuery(memberId, null, statusId, null, null, null, null, null, null, pageable);
   }
   
   public static TodoListQuery of(UUID memberId, Integer statusId, String keyword, Pageable pageable) {
-    return new TodoListQuery(memberId, null, statusId, null, null, keyword, null, pageable);
+    return new TodoListQuery(memberId, null, statusId, null, null, keyword, null, null, null, pageable);
   }
   
   public static TodoListQuery of(UUID memberId, String keyword, Pageable pageable) {
-    return new TodoListQuery(memberId, null, null, null, null, keyword, null, pageable);
+    return new TodoListQuery(memberId, null, null, null, null, keyword, null, null, null, pageable);
   }
   
   public static TodoListQuery of(UUID memberId, Integer statusId, Long categoryId, Integer priorityId, String keyword, Pageable pageable) {
-    return new TodoListQuery(memberId, null, statusId, categoryId, priorityId, keyword, null, pageable);
+    return new TodoListQuery(memberId, null, statusId, categoryId, priorityId, keyword, null, null, null, pageable);
   }
 
   public static TodoListQuery of(UUID memberId, Integer statusId, Long categoryId,
                                  Integer priorityId, String keyword, List<Integer> hideStatusIds,
                                  Pageable pageable) {
-    return new TodoListQuery(memberId, null, statusId, categoryId, priorityId, keyword, hideStatusIds, pageable);
+    return new TodoListQuery(memberId, null, statusId, categoryId, priorityId, keyword, hideStatusIds, null, null, pageable);
   }
   
   public static TodoListQuery ofAll(UUID memberId, Pageable pageable) {
-    return new TodoListQuery(memberId, null, null, null, null, null, null, pageable);
+    return new TodoListQuery(memberId, null, null, null, null, null, null, null, null, pageable);
+  }
+
+  public static TodoListQuery of(UUID memberId, Integer statusId, Long categoryId,
+                                 Integer priorityId, String keyword, List<Integer> hideStatusIds,
+                                 Instant startDate, Instant endDate,
+                                 Pageable pageable) {
+    return new TodoListQuery(memberId, null, statusId, categoryId, priorityId, keyword,
+            hideStatusIds, startDate, endDate, pageable);
   }
 }

--- a/src/main/java/point/zzicback/todo/application/dto/result/TodoResult.java
+++ b/src/main/java/point/zzicback/todo/application/dto/result/TodoResult.java
@@ -2,7 +2,7 @@ package point.zzicback.todo.application.dto.result;
 
 import point.zzicback.todo.domain.RepeatType;
 
-import java.time.LocalDate;
+import java.time.Instant;
 import java.util.Set;
 
 public record TodoResult(
@@ -15,7 +15,7 @@ public record TodoResult(
         String priorityName,
         Long categoryId,
         String categoryName,
-        LocalDate dueDate,
+        Instant dueDate,
         RepeatType repeatType,
         Set<String> tags
 ) {

--- a/src/main/java/point/zzicback/todo/config/TodoInitializer.java
+++ b/src/main/java/point/zzicback/todo/config/TodoInitializer.java
@@ -9,7 +9,8 @@ import point.zzicback.category.infrastructure.CategoryRepository;
 import point.zzicback.member.domain.Member;
 import point.zzicback.todo.domain.*;
 
-import java.time.LocalDate;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.*;
 
 @Slf4j
@@ -49,7 +50,7 @@ public class TodoInitializer implements ApplicationRunner {
             .description("이 할일을 완료 상태로 변경해보세요. 예: 오늘 할일을 체크해보세요.")
             .priorityId(1)
             .category(categoryMap.getOrDefault("개인", categories.isEmpty() ? null : categories.getFirst()))
-            .dueDate(LocalDate.now().plusDays(2))
+            .dueDate(Instant.now().plus(2, ChronoUnit.DAYS))
             .tags(Set.of("시작", "튜토리얼"))
             .member(member)
             .build());
@@ -60,7 +61,7 @@ public class TodoInitializer implements ApplicationRunner {
             .description("하루를 시작하기 전 15분 명상으로 마음 정리하기")
             .priorityId(2)
             .category(categoryMap.getOrDefault("개인", categories.isEmpty() ? null : categories.getFirst()))
-            .dueDate(LocalDate.now())
+            .dueDate(Instant.now())
             .tags(Set.of("명상", "습관", "아침"))
             .member(member)
             .build());
@@ -70,7 +71,7 @@ public class TodoInitializer implements ApplicationRunner {
             .description("오늘 하루 있었던 일과 감정 정리하기")
             .priorityId(1)
             .category(categoryMap.getOrDefault("개인", categories.isEmpty() ? null : categories.getFirst()))
-            .dueDate(LocalDate.now())
+            .dueDate(Instant.now())
             .tags(Set.of("일기", "성찰", "습관"))
             .member(member)
             .build());
@@ -80,7 +81,7 @@ public class TodoInitializer implements ApplicationRunner {
             .description("이번 주 성취할 3가지 목표 구체적으로 작성하기")
             .priorityId(2)
             .category(categoryMap.getOrDefault("개인", categories.isEmpty() ? null : categories.getFirst()))
-            .dueDate(LocalDate.now().minusDays(3))
+            .dueDate(Instant.now().minus(3, ChronoUnit.DAYS))
             .tags(Set.of("목표", "계획", "성장"))
             .member(member)
             .build());
@@ -90,7 +91,7 @@ public class TodoInitializer implements ApplicationRunner {
             .description("오늘 30페이지 읽고 중요 내용 메모하기")
             .priorityId(1)
             .category(categoryMap.getOrDefault("개인", categories.isEmpty() ? null : categories.getFirst()))
-            .dueDate(LocalDate.now().plusDays(1))
+            .dueDate(Instant.now().plus(1, ChronoUnit.DAYS))
             .tags(Set.of("독서", "성장", "지식"))
             .member(member)
             .build());
@@ -100,7 +101,7 @@ public class TodoInitializer implements ApplicationRunner {
             .description("주말 개봉하는 '인터스텔라 2' 예매하기")
             .priorityId(0)
             .category(categoryMap.getOrDefault("개인", categories.isEmpty() ? null : categories.getFirst()))
-            .dueDate(LocalDate.now().plusDays(2))
+            .dueDate(Instant.now().plus(2, ChronoUnit.DAYS))
             .tags(Set.of("취미", "영화", "여가"))
             .member(member)
             .build());
@@ -110,7 +111,7 @@ public class TodoInitializer implements ApplicationRunner {
             .description("다음 주 수요일 오후 2시, 김스타일 미용실")
             .priorityId(0)
             .category(categoryMap.getOrDefault("개인", categories.isEmpty() ? null : categories.getFirst()))
-            .dueDate(LocalDate.now().plusDays(3))
+            .dueDate(Instant.now().plus(3, ChronoUnit.DAYS))
             .tags(Set.of("미용", "예약", "관리"))
             .member(member)
             .build());
@@ -120,7 +121,7 @@ public class TodoInitializer implements ApplicationRunner {
             .description("옷장 정리 및 책상 먼지 제거하기")
             .priorityId(1)
             .category(categoryMap.getOrDefault("개인", categories.isEmpty() ? null : categories.getFirst()))
-            .dueDate(LocalDate.now().minusDays(1))
+            .dueDate(Instant.now().minus(1, ChronoUnit.DAYS))
             .tags(Set.of("청소", "정리", "집"))
             .member(member)
             .build());
@@ -130,7 +131,7 @@ public class TodoInitializer implements ApplicationRunner {
             .description("종합비타민과 오메가3 온라인으로 주문하기")
             .priorityId(0)
             .category(categoryMap.getOrDefault("개인", categories.isEmpty() ? null : categories.getFirst()))
-            .dueDate(LocalDate.now().plusDays(1))
+            .dueDate(Instant.now().plus(1, ChronoUnit.DAYS))
             .tags(Set.of("건강", "쇼핑", "영양제"))
             .member(member)
             .build());
@@ -140,7 +141,7 @@ public class TodoInitializer implements ApplicationRunner {
             .description("운동화 사이즈 270, 블랙 또는 네이비 색상")
             .priorityId(0)
             .category(categoryMap.getOrDefault("개인", categories.isEmpty() ? null : categories.getFirst()))
-            .dueDate(LocalDate.now().plusDays(3))
+            .dueDate(Instant.now().plus(3, ChronoUnit.DAYS))
             .tags(Set.of("쇼핑", "패션", "신발"))
             .member(member)
             .build());
@@ -150,7 +151,7 @@ public class TodoInitializer implements ApplicationRunner {
             .description("원두 250g 구매, 에티오피아 예가체프 선호")
             .priorityId(1)
             .category(categoryMap.getOrDefault("개인", categories.isEmpty() ? null : categories.getFirst()))
-            .dueDate(LocalDate.now().minusDays(2))
+            .dueDate(Instant.now().minus(2, ChronoUnit.DAYS))
             .tags(Set.of("커피", "쇼핑", "취미"))
             .member(member)
             .build());
@@ -160,7 +161,7 @@ public class TodoInitializer implements ApplicationRunner {
             .description("여행 후기 및 사진 정리해서 올리기")
             .priorityId(0)
             .category(categoryMap.getOrDefault("개인", categories.isEmpty() ? null : categories.getFirst()))
-            .dueDate(LocalDate.now().minusDays(1))
+            .dueDate(Instant.now().minus(1, ChronoUnit.DAYS))
             .tags(Set.of("블로그", "글쓰기", "취미"))
             .member(member)
             .build());
@@ -170,7 +171,7 @@ public class TodoInitializer implements ApplicationRunner {
             .description("거실과 서재의 식물에 물주기")
             .priorityId(1)
             .category(categoryMap.getOrDefault("개인", categories.isEmpty() ? null : categories.getFirst()))
-            .dueDate(LocalDate.now())
+            .dueDate(Instant.now())
             .tags(Set.of("식물", "가꾸기", "집"))
             .member(member)
             .build());
@@ -180,7 +181,7 @@ public class TodoInitializer implements ApplicationRunner {
             .description("이번 주 토론 주제 \"인공지능과 미래\" 발표 자료 준비")
             .priorityId(1)
             .category(categoryMap.getOrDefault("개인", categories.isEmpty() ? null : categories.getFirst()))
-            .dueDate(LocalDate.now().plusDays(2))
+            .dueDate(Instant.now().plus(2, ChronoUnit.DAYS))
             .tags(Set.of("독서", "모임", "발표"))
             .member(member)
             .build());
@@ -190,7 +191,7 @@ public class TodoInitializer implements ApplicationRunner {
             .description("디자이너가 보낸 명함 시안 3개 검토 후 피드백 주기")
             .priorityId(0)
             .category(categoryMap.getOrDefault("개인", categories.isEmpty() ? null : categories.getFirst()))
-            .dueDate(LocalDate.now().minusDays(3))
+            .dueDate(Instant.now().minus(3, ChronoUnit.DAYS))
             .tags(Set.of("디자인", "명함", "피드백"))
             .member(member)
             .build());
@@ -200,7 +201,7 @@ public class TodoInitializer implements ApplicationRunner {
             .description("8월 첫째 주 제주도 3박4일 여행 일정 계획하기")
             .priorityId(1)
             .category(categoryMap.getOrDefault("개인", categories.isEmpty() ? null : categories.getFirst()))
-            .dueDate(LocalDate.now().plusDays(3))
+            .dueDate(Instant.now().plus(3, ChronoUnit.DAYS))
             .tags(Set.of("여행", "계획", "휴가"))
             .member(member)
             .build());
@@ -211,7 +212,7 @@ public class TodoInitializer implements ApplicationRunner {
             .description("업무 카테고리에 회의 준비 자료를 정리해보세요. 예: 회의 안건 정리, 자료 출력 등")
             .priorityId(1)
             .category(categoryMap.getOrDefault("업무", categories.isEmpty() ? null : categories.getFirst()))
-            .dueDate(LocalDate.now().plusDays(1))
+            .dueDate(Instant.now().plus(1, ChronoUnit.DAYS))
             .tags(Set.of("회의", "업무", "중요"))
             .member(member)
             .build());
@@ -221,7 +222,7 @@ public class TodoInitializer implements ApplicationRunner {
             .description("지난 주 성과와 다음 주 계획을 포함한 보고서 작성하기")
             .priorityId(2)
             .category(categoryMap.getOrDefault("업무", categories.isEmpty() ? null : categories.getFirst()))
-            .dueDate(LocalDate.now().minusDays(3))
+            .dueDate(Instant.now().minus(3, ChronoUnit.DAYS))
             .tags(Set.of("보고서", "업무", "마감"))
             .member(member)
             .build());
@@ -231,7 +232,7 @@ public class TodoInitializer implements ApplicationRunner {
             .description("7월 출시 예정인 프로젝트 진행 상황 점검 및 일정 조정")
             .priorityId(2)
             .category(categoryMap.getOrDefault("업무", categories.isEmpty() ? null : categories.getFirst()))
-            .dueDate(LocalDate.now())
+            .dueDate(Instant.now())
             .tags(Set.of("프로젝트", "일정", "관리"))
             .member(member)
             .build());
@@ -241,7 +242,7 @@ public class TodoInitializer implements ApplicationRunner {
             .description("부서 간 협업 방안에 대한 안건 준비하기")
             .priorityId(2)
             .category(categoryMap.getOrDefault("업무", categories.isEmpty() ? null : categories.getFirst()))
-            .dueDate(LocalDate.now().plusDays(1))
+            .dueDate(Instant.now().plus(1, ChronoUnit.DAYS))
             .tags(Set.of("미팅", "팀워크", "협업"))
             .member(member)
             .build());
@@ -251,7 +252,7 @@ public class TodoInitializer implements ApplicationRunner {
             .description("미처리 이메일 답장 및 중요 메일 폴더 정리하기")
             .priorityId(1)
             .category(categoryMap.getOrDefault("업무", categories.isEmpty() ? null : categories.getFirst()))
-            .dueDate(LocalDate.now().minusDays(1))
+            .dueDate(Instant.now().minus(1, ChronoUnit.DAYS))
             .tags(Set.of("이메일", "정리", "커뮤니케이션"))
             .member(member)
             .build());
@@ -261,7 +262,7 @@ public class TodoInitializer implements ApplicationRunner {
             .description("온보딩 프로세스 및 업무 매뉴얼 업데이트하기")
             .priorityId(1)
             .category(categoryMap.getOrDefault("업무", categories.isEmpty() ? null : categories.getFirst()))
-            .dueDate(LocalDate.now().plusDays(2))
+            .dueDate(Instant.now().plus(2, ChronoUnit.DAYS))
             .tags(Set.of("교육", "인사", "매뉴얼"))
             .member(member)
             .build());
@@ -271,7 +272,7 @@ public class TodoInitializer implements ApplicationRunner {
             .description("A사 담당자와의 계약 갱신 관련 미팅 자료 준비")
             .priorityId(2)
             .category(categoryMap.getOrDefault("업무", categories.isEmpty() ? null : categories.getFirst()))
-            .dueDate(LocalDate.now().plusDays(3))
+            .dueDate(Instant.now().plus(3, ChronoUnit.DAYS))
             .tags(Set.of("거래처", "계약", "미팅"))
             .member(member)
             .build());
@@ -281,7 +282,7 @@ public class TodoInitializer implements ApplicationRunner {
             .description("2/4분기 판매 실적 분석 및 보고서 작성하기")
             .priorityId(2)
             .category(categoryMap.getOrDefault("업무", categories.isEmpty() ? null : categories.getFirst()))
-            .dueDate(LocalDate.now().minusDays(2))
+            .dueDate(Instant.now().minus(2, ChronoUnit.DAYS))
             .tags(Set.of("분석", "실적", "보고서"))
             .member(member)
             .build());
@@ -291,7 +292,7 @@ public class TodoInitializer implements ApplicationRunner {
             .description("지난 출장 경비 내역 정리 및 영수증 제출하기")
             .priorityId(1)
             .category(categoryMap.getOrDefault("업무", categories.isEmpty() ? null : categories.getFirst()))
-            .dueDate(LocalDate.now())
+            .dueDate(Instant.now())
             .tags(Set.of("경비", "정산", "출장"))
             .member(member)
             .build());
@@ -301,7 +302,7 @@ public class TodoInitializer implements ApplicationRunner {
             .description("최근 접수된 고객 피드백 분석 및 개선안 도출하기")
             .priorityId(1)
             .category(categoryMap.getOrDefault("업무", categories.isEmpty() ? null : categories.getFirst()))
-            .dueDate(LocalDate.now().plusDays(2))
+            .dueDate(Instant.now().plus(2, ChronoUnit.DAYS))
             .tags(Set.of("고객", "피드백", "개선"))
             .member(member)
             .build());
@@ -311,7 +312,7 @@ public class TodoInitializer implements ApplicationRunner {
             .description("사용성 향상을 위한 웹사이트 UI/UX 개선점 정리하기")
             .priorityId(1)
             .category(categoryMap.getOrDefault("업무", categories.isEmpty() ? null : categories.getFirst()))
-            .dueDate(LocalDate.now().minusDays(1))
+            .dueDate(Instant.now().minus(1, ChronoUnit.DAYS))
             .tags(Set.of("웹사이트", "UI", "기획"))
             .member(member)
             .build());
@@ -321,7 +322,7 @@ public class TodoInitializer implements ApplicationRunner {
             .description("신규 시스템 도입에 따른 업무 프로세스 매뉴얼 갱신하기")
             .priorityId(0)
             .category(categoryMap.getOrDefault("업무", categories.isEmpty() ? null : categories.getFirst()))
-            .dueDate(LocalDate.now().plusDays(3))
+            .dueDate(Instant.now().plus(3, ChronoUnit.DAYS))
             .tags(Set.of("매뉴얼", "프로세스", "문서"))
             .member(member)
             .build());
@@ -331,7 +332,7 @@ public class TodoInitializer implements ApplicationRunner {
             .description("3분기 마케팅 캠페인 전략 수립 회의 참석하기")
             .priorityId(2)
             .category(categoryMap.getOrDefault("업무", categories.isEmpty() ? null : categories.getFirst()))
-            .dueDate(LocalDate.now().plusDays(1))
+            .dueDate(Instant.now().plus(1, ChronoUnit.DAYS))
             .tags(Set.of("마케팅", "전략", "회의"))
             .member(member)
             .build());
@@ -341,7 +342,7 @@ public class TodoInitializer implements ApplicationRunner {
             .description("팀원 반기 인사평가를 위한 실적 자료 준비하기")
             .priorityId(1)
             .category(categoryMap.getOrDefault("업무", categories.isEmpty() ? null : categories.getFirst()))
-            .dueDate(LocalDate.now().minusDays(2))
+            .dueDate(Instant.now().minus(2, ChronoUnit.DAYS))
             .tags(Set.of("인사", "평가", "관리"))
             .member(member)
             .build());
@@ -351,7 +352,7 @@ public class TodoInitializer implements ApplicationRunner {
             .description("신규 개발된 API 문서 검토 및 피드백 제공하기")
             .priorityId(1)
             .category(categoryMap.getOrDefault("업무", categories.isEmpty() ? null : categories.getFirst()))
-            .dueDate(LocalDate.now())
+            .dueDate(Instant.now())
             .tags(Set.of("개발", "API", "문서"))
             .member(member)
             .build());
@@ -361,7 +362,7 @@ public class TodoInitializer implements ApplicationRunner {
             .description("프로젝트 잠재 리스크 분석 및 대응 방안 문서화하기")
             .priorityId(1)
             .category(categoryMap.getOrDefault("업무", categories.isEmpty() ? null : categories.getFirst()))
-            .dueDate(LocalDate.now().plusDays(2))
+            .dueDate(Instant.now().plus(2, ChronoUnit.DAYS))
             .tags(Set.of("리스크", "관리", "프로젝트"))
             .member(member)
             .build());
@@ -371,7 +372,7 @@ public class TodoInitializer implements ApplicationRunner {
             .title("영어 단어 암기")
             .description("하루에 영어 단어 10개 외우기")
             .priorityId(0)
-            .dueDate(LocalDate.now().plusDays(7))
+            .dueDate(Instant.now().plus(7, ChronoUnit.DAYS))
             .category(categoryMap.getOrDefault("공부", categories.isEmpty() ? null : categories.getFirst()))
             .tags(Set.of("영어", "학습", "반복"))
             .member(member)
@@ -382,7 +383,7 @@ public class TodoInitializer implements ApplicationRunner {
             .description("프로그래머스 Level 2 문제 3개 풀기")
             .priorityId(1)
             .category(categoryMap.getOrDefault("공부", categories.isEmpty() ? null : categories.getFirst()))
-            .dueDate(LocalDate.now())
+            .dueDate(Instant.now())
             .tags(Set.of("알고리즘", "코딩", "문제해결"))
             .member(member)
             .build());
@@ -392,7 +393,7 @@ public class TodoInitializer implements ApplicationRunner {
             .description("인프런 김영한 강사 강의 Section 4 완료하기")
             .priorityId(1)
             .category(categoryMap.getOrDefault("공부", categories.isEmpty() ? null : categories.getFirst()))
-            .dueDate(LocalDate.now().plusDays(1))
+            .dueDate(Instant.now().plus(1, ChronoUnit.DAYS))
             .tags(Set.of("개발", "스프링", "강의"))
             .member(member)
             .build());
@@ -402,7 +403,7 @@ public class TodoInitializer implements ApplicationRunner {
             .description("판매 데이터 분석 및 인사이트 도출 보고서 작성하기")
             .priorityId(2)
             .category(categoryMap.getOrDefault("공부", categories.isEmpty() ? null : categories.getFirst()))
-            .dueDate(LocalDate.now().plusDays(3))
+            .dueDate(Instant.now().plus(3, ChronoUnit.DAYS))
             .tags(Set.of("데이터", "분석", "과제"))
             .member(member)
             .build());
@@ -412,7 +413,7 @@ public class TodoInitializer implements ApplicationRunner {
             .description("JLPT N3 문법 중 조건문 표현 복습하기")
             .priorityId(0)
             .category(categoryMap.getOrDefault("공부", categories.isEmpty() ? null : categories.getFirst()))
-            .dueDate(LocalDate.now().minusDays(1))
+            .dueDate(Instant.now().minus(1, ChronoUnit.DAYS))
             .tags(Set.of("일본어", "문법", "복습"))
             .member(member)
             .build());
@@ -422,7 +423,7 @@ public class TodoInitializer implements ApplicationRunner {
             .description("팩토리 패턴과 옵저버 패턴 개념 학습하기")
             .priorityId(1)
             .category(categoryMap.getOrDefault("공부", categories.isEmpty() ? null : categories.getFirst()))
-            .dueDate(LocalDate.now().minusDays(2))
+            .dueDate(Instant.now().minus(2, ChronoUnit.DAYS))
             .tags(Set.of("개발", "디자인패턴", "스터디"))
             .member(member)
             .build());
@@ -432,7 +433,7 @@ public class TodoInitializer implements ApplicationRunner {
             .description("확률분포와 가설검정 개념 복습 및 문제 풀이")
             .priorityId(0)
             .category(categoryMap.getOrDefault("공부", categories.isEmpty() ? null : categories.getFirst()))
-            .dueDate(LocalDate.now())
+            .dueDate(Instant.now())
             .tags(Set.of("통계", "수학", "복습"))
             .member(member)
             .build());
@@ -442,7 +443,7 @@ public class TodoInitializer implements ApplicationRunner {
             .description("AWS 기초 서비스 개념 및 사용법 숙지하기")
             .priorityId(1)
             .category(categoryMap.getOrDefault("공부", categories.isEmpty() ? null : categories.getFirst()))
-            .dueDate(LocalDate.now().plusDays(2))
+            .dueDate(Instant.now().plus(2, ChronoUnit.DAYS))
             .tags(Set.of("AWS", "클라우드", "IT"))
             .member(member)
             .build());
@@ -452,7 +453,7 @@ public class TodoInitializer implements ApplicationRunner {
             .description("'퍼스웨이전' 4장까지 읽고 핵심 개념 정리하기")
             .priorityId(0)
             .category(categoryMap.getOrDefault("공부", categories.isEmpty() ? null : categories.getFirst()))
-            .dueDate(LocalDate.now().minusDays(3))
+            .dueDate(Instant.now().minus(3, ChronoUnit.DAYS))
             .tags(Set.of("마케팅", "독서", "전략"))
             .member(member)
             .build());
@@ -462,7 +463,7 @@ public class TodoInitializer implements ApplicationRunner {
             .description("부동산 투자 기초 강의 2개 수강하기")
             .priorityId(0)
             .category(categoryMap.getOrDefault("공부", categories.isEmpty() ? null : categories.getFirst()))
-            .dueDate(LocalDate.now().plusDays(1))
+            .dueDate(Instant.now().plus(1, ChronoUnit.DAYS))
             .tags(Set.of("재테크", "투자", "강의"))
             .member(member)
             .build());
@@ -472,7 +473,7 @@ public class TodoInitializer implements ApplicationRunner {
             .description("이미지 합성 및 색상 보정 기법 연습하기")
             .priorityId(0)
             .category(categoryMap.getOrDefault("공부", categories.isEmpty() ? null : categories.getFirst()))
-            .dueDate(LocalDate.now().minusDays(1))
+            .dueDate(Instant.now().minus(1, ChronoUnit.DAYS))
             .tags(Set.of("디자인", "포토샵", "실습"))
             .member(member)
             .build());
@@ -482,7 +483,7 @@ public class TodoInitializer implements ApplicationRunner {
             .description("복잡한 조인과 서브쿼리 문제 5개 풀기")
             .priorityId(1)
             .category(categoryMap.getOrDefault("공부", categories.isEmpty() ? null : categories.getFirst()))
-            .dueDate(LocalDate.now())
+            .dueDate(Instant.now())
             .tags(Set.of("데이터베이스", "SQL", "개발"))
             .member(member)
             .build());
@@ -492,7 +493,7 @@ public class TodoInitializer implements ApplicationRunner {
             .description("언어 교환 앱에서 30분 스페인어로 대화하기")
             .priorityId(0)
             .category(categoryMap.getOrDefault("공부", categories.isEmpty() ? null : categories.getFirst()))
-            .dueDate(LocalDate.now().plusDays(2))
+            .dueDate(Instant.now().plus(2, ChronoUnit.DAYS))
             .tags(Set.of("스페인어", "회화", "언어"))
             .member(member)
             .build());
@@ -502,7 +503,7 @@ public class TodoInitializer implements ApplicationRunner {
             .description("행동경제학 관련 논문 1편 읽고 요약하기")
             .priorityId(0)
             .category(categoryMap.getOrDefault("공부", categories.isEmpty() ? null : categories.getFirst()))
-            .dueDate(LocalDate.now().minusDays(2))
+            .dueDate(Instant.now().minus(2, ChronoUnit.DAYS))
             .tags(Set.of("심리학", "논문", "연구"))
             .member(member)
             .build());
@@ -512,7 +513,7 @@ public class TodoInitializer implements ApplicationRunner {
             .description("효과적인 프로젝트 기획서 작성 방법 익히기")
             .priorityId(1)
             .category(categoryMap.getOrDefault("공부", categories.isEmpty() ? null : categories.getFirst()))
-            .dueDate(LocalDate.now().plusDays(3))
+            .dueDate(Instant.now().plus(3, ChronoUnit.DAYS))
             .tags(Set.of("기획", "문서", "프로젝트"))
             .member(member)
             .build());
@@ -523,7 +524,7 @@ public class TodoInitializer implements ApplicationRunner {
             .description("저녁 6시에 가족들과 식사.")
             .priorityId(1)
             .category(categoryMap.getOrDefault("가족", categories.isEmpty() ? null : categories.getFirst()))
-            .dueDate(LocalDate.now())
+            .dueDate(Instant.now())
             .tags(Set.of("가족", "식사", "저녁"))
             .member(member)
             .build());
@@ -533,7 +534,7 @@ public class TodoInitializer implements ApplicationRunner {
             .description("어버이날 선물로 건강식품 구매하기")
             .priorityId(1)
             .category(categoryMap.getOrDefault("가족", categories.isEmpty() ? null : categories.getFirst()))
-            .dueDate(LocalDate.now().plusDays(2))
+            .dueDate(Instant.now().plus(2, ChronoUnit.DAYS))
             .tags(Set.of("선물", "부모님", "효도"))
             .member(member)
             .build());
@@ -543,7 +544,7 @@ public class TodoInitializer implements ApplicationRunner {
             .description("여름휴가 제주도 여행 일정 및 숙소 예약하기")
             .priorityId(2)
             .category(categoryMap.getOrDefault("가족", categories.isEmpty() ? null : categories.getFirst()))
-            .dueDate(LocalDate.now().plusDays(3))
+            .dueDate(Instant.now().plus(3, ChronoUnit.DAYS))
             .tags(Set.of("여행", "가족", "계획"))
             .member(member)
             .build());
@@ -553,7 +554,7 @@ public class TodoInitializer implements ApplicationRunner {
             .description("예방접종 일정 예약하기, 소아과")
             .priorityId(2)
             .category(categoryMap.getOrDefault("가족", categories.isEmpty() ? null : categories.getFirst()))
-            .dueDate(LocalDate.now().minusDays(1))
+            .dueDate(Instant.now().minus(1, ChronoUnit.DAYS))
             .tags(Set.of("병원", "아이", "건강"))
             .member(member)
             .build());
@@ -563,7 +564,7 @@ public class TodoInitializer implements ApplicationRunner {
             .description("외가 친척들 방문, 간식 및 식사 준비하기")
             .priorityId(1)
             .category(categoryMap.getOrDefault("가족", categories.isEmpty() ? null : categories.getFirst()))
-            .dueDate(LocalDate.now().plusDays(1))
+            .dueDate(Instant.now().plus(1, ChronoUnit.DAYS))
             .tags(Set.of("모임", "친척", "준비"))
             .member(member)
             .build());
@@ -573,7 +574,7 @@ public class TodoInitializer implements ApplicationRunner {
             .description("담임 선생님과 학업 및 진로 상담, 오후 4시")
             .priorityId(2)
             .category(categoryMap.getOrDefault("가족", categories.isEmpty() ? null : categories.getFirst()))
-            .dueDate(LocalDate.now().minusDays(2))
+            .dueDate(Instant.now().minus(2, ChronoUnit.DAYS))
             .tags(Set.of("상담", "학교", "교육"))
             .member(member)
             .build());
@@ -583,7 +584,7 @@ public class TodoInitializer implements ApplicationRunner {
             .description("지난달 여행 사진 인화 및 앨범 정리하기")
             .priorityId(0)
             .category(categoryMap.getOrDefault("가족", categories.isEmpty() ? null : categories.getFirst()))
-            .dueDate(LocalDate.now())
+            .dueDate(Instant.now())
             .tags(Set.of("사진", "추억", "정리"))
             .member(member)
             .build());
@@ -593,7 +594,7 @@ public class TodoInitializer implements ApplicationRunner {
             .description("영어 학원 상담 및 등록 절차 진행하기")
             .priorityId(1)
             .category(categoryMap.getOrDefault("가족", categories.isEmpty() ? null : categories.getFirst()))
-            .dueDate(LocalDate.now().plusDays(2))
+            .dueDate(Instant.now().plus(2, ChronoUnit.DAYS))
             .tags(Set.of("교육", "학원", "아이"))
             .member(member)
             .build());
@@ -603,7 +604,7 @@ public class TodoInitializer implements ApplicationRunner {
             .description("차례 음식 준비 및 선물 구매 계획 세우기")
             .priorityId(1)
             .category(categoryMap.getOrDefault("가족", categories.isEmpty() ? null : categories.getFirst()))
-            .dueDate(LocalDate.now().plusDays(3))
+            .dueDate(Instant.now().plus(3, ChronoUnit.DAYS))
             .tags(Set.of("명절", "준비", "계획"))
             .member(member)
             .build());
@@ -613,7 +614,7 @@ public class TodoInitializer implements ApplicationRunner {
             .description("이번 주 저녁 식단 계획 및 장보기 목록 작성하기")
             .priorityId(0)
             .category(categoryMap.getOrDefault("가족", categories.isEmpty() ? null : categories.getFirst()))
-            .dueDate(LocalDate.now().minusDays(3))
+            .dueDate(Instant.now().minus(3, ChronoUnit.DAYS))
             .tags(Set.of("식단", "계획", "가족"))
             .member(member)
             .build());
@@ -624,7 +625,7 @@ public class TodoInitializer implements ApplicationRunner {
             .description("친구들과 점심 약속.")
             .priorityId(1)
             .category(categoryMap.getOrDefault("약속", categories.isEmpty() ? null : categories.getFirst()))
-            .dueDate(LocalDate.now().plusDays(1))
+            .dueDate(Instant.now().plus(1, ChronoUnit.DAYS))
             .tags(Set.of("친구", "점심", "사교"))
             .member(member)
             .build());
@@ -634,7 +635,7 @@ public class TodoInitializer implements ApplicationRunner {
             .description("고등학교 10주년 동창회, 강남역 모임장소")
             .priorityId(1)
             .category(categoryMap.getOrDefault("약속", categories.isEmpty() ? null : categories.getFirst()))
-            .dueDate(LocalDate.now().plusDays(3))
+            .dueDate(Instant.now().plus(3, ChronoUnit.DAYS))
             .tags(Set.of("동창회", "친구", "모임"))
             .member(member)
             .build());
@@ -644,7 +645,7 @@ public class TodoInitializer implements ApplicationRunner {
             .description("협력사 담당자와 오후 2시 카페에서 미팅")
             .priorityId(2)
             .category(categoryMap.getOrDefault("약속", categories.isEmpty() ? null : categories.getFirst()))
-            .dueDate(LocalDate.now())
+            .dueDate(Instant.now())
             .tags(Set.of("업무", "미팅", "네트워킹"))
             .member(member)
             .build());
@@ -654,7 +655,7 @@ public class TodoInitializer implements ApplicationRunner {
             .description("경력 개발 관련 멘토와의 온라인 미팅")
             .priorityId(1)
             .category(categoryMap.getOrDefault("약속", categories.isEmpty() ? null : categories.getFirst()))
-            .dueDate(LocalDate.now().minusDays(1))
+            .dueDate(Instant.now().minus(1, ChronoUnit.DAYS))
             .tags(Set.of("멘토링", "경력", "성장"))
             .member(member)
             .build());
@@ -664,7 +665,7 @@ public class TodoInitializer implements ApplicationRunner {
             .description("저녁 7시, 홍대 레스토랑에서 생일 축하 모임")
             .priorityId(1)
             .category(categoryMap.getOrDefault("약속", categories.isEmpty() ? null : categories.getFirst()))
-            .dueDate(LocalDate.now().plusDays(2))
+            .dueDate(Instant.now().plus(2, ChronoUnit.DAYS))
             .tags(Set.of("생일", "축하", "친구"))
             .member(member)
             .build());
@@ -674,7 +675,7 @@ public class TodoInitializer implements ApplicationRunner {
             .description("프로그래밍 스터디, 강남역 스터디카페")
             .priorityId(2)
             .category(categoryMap.getOrDefault("약속", categories.isEmpty() ? null : categories.getFirst()))
-            .dueDate(LocalDate.now().minusDays(2))
+            .dueDate(Instant.now().minus(2, ChronoUnit.DAYS))
             .tags(Set.of("스터디", "개발", "학습"))
             .member(member)
             .build());
@@ -684,7 +685,7 @@ public class TodoInitializer implements ApplicationRunner {
             .description("사진 동호회 정기 모임 및 출사")
             .priorityId(0)
             .category(categoryMap.getOrDefault("약속", categories.isEmpty() ? null : categories.getFirst()))
-            .dueDate(LocalDate.now().minusDays(3))
+            .dueDate(Instant.now().minus(3, ChronoUnit.DAYS))
             .tags(Set.of("취미", "사진", "모임"))
             .member(member)
             .build());
@@ -694,7 +695,7 @@ public class TodoInitializer implements ApplicationRunner {
             .description("건강검진 예약, 오전 10시 종합병원")
             .priorityId(2)
             .category(categoryMap.getOrDefault("약속", categories.isEmpty() ? null : categories.getFirst()))
-            .dueDate(LocalDate.now().plusDays(1))
+            .dueDate(Instant.now().plus(1, ChronoUnit.DAYS))
             .tags(Set.of("병원", "건강", "검진"))
             .member(member)
             .build());
@@ -704,7 +705,7 @@ public class TodoInitializer implements ApplicationRunner {
             .description("신규 아파트 분양 상담, 오후 3시")
             .priorityId(1)
             .category(categoryMap.getOrDefault("약속", categories.isEmpty() ? null : categories.getFirst()))
-            .dueDate(LocalDate.now().plusDays(3))
+            .dueDate(Instant.now().plus(3, ChronoUnit.DAYS))
             .tags(Set.of("부동산", "상담", "주택"))
             .member(member)
             .build());
@@ -714,7 +715,7 @@ public class TodoInitializer implements ApplicationRunner {
             .description("개발자 컨퍼런스 줌 미팅, 저녁 8시")
             .priorityId(1)
             .category(categoryMap.getOrDefault("약속", categories.isEmpty() ? null : categories.getFirst()))
-            .dueDate(LocalDate.now())
+            .dueDate(Instant.now())
             .tags(Set.of("컨퍼런스", "개발", "온라인"))
             .member(member)
             .build());
@@ -725,7 +726,7 @@ public class TodoInitializer implements ApplicationRunner {
             .description("복근 운동 3세트, 유산소 20분")
             .priorityId(0)
             .category(categoryMap.getOrDefault("운동", categories.isEmpty() ? null : categories.getFirst()))
-            .dueDate(LocalDate.now().plusDays(1))
+            .dueDate(Instant.now().plus(1, ChronoUnit.DAYS))
             .tags(Set.of("운동", "건강", "복근"))
             .member(member)
             .build());
@@ -735,7 +736,7 @@ public class TodoInitializer implements ApplicationRunner {
             .description("오후 7시, 상체 중점 트레이닝")
             .priorityId(1)
             .category(categoryMap.getOrDefault("운동", categories.isEmpty() ? null : categories.getFirst()))
-            .dueDate(LocalDate.now())
+            .dueDate(Instant.now())
             .tags(Set.of("PT", "헬스", "예약"))
             .member(member)
             .build());
@@ -745,7 +746,7 @@ public class TodoInitializer implements ApplicationRunner {
             .description("조깅용 신발 구매, 스포츠 브랜드 매장 방문")
             .priorityId(0)
             .category(categoryMap.getOrDefault("운동", categories.isEmpty() ? null : categories.getFirst()))
-            .dueDate(LocalDate.now().plusDays(2))
+            .dueDate(Instant.now().plus(2, ChronoUnit.DAYS))
             .tags(Set.of("쇼핑", "운동용품", "러닝"))
             .member(member)
             .build());
@@ -755,7 +756,7 @@ public class TodoInitializer implements ApplicationRunner {
             .description("오전 10시, 코어 강화 클래스")
             .priorityId(1)
             .category(categoryMap.getOrDefault("운동", categories.isEmpty() ? null : categories.getFirst()))
-            .dueDate(LocalDate.now().minusDays(1))
+            .dueDate(Instant.now().minus(1, ChronoUnit.DAYS))
             .tags(Set.of("필라테스", "코어", "건강"))
             .member(member)
             .build());
@@ -765,7 +766,7 @@ public class TodoInitializer implements ApplicationRunner {
             .description("HIIT 15분, 스쿼트 20개 3세트")
             .priorityId(1)
             .category(categoryMap.getOrDefault("운동", categories.isEmpty() ? null : categories.getFirst()))
-            .dueDate(LocalDate.now().minusDays(2))
+            .dueDate(Instant.now().minus(2, ChronoUnit.DAYS))
             .tags(Set.of("홈트", "HIIT", "스쿼트"))
             .member(member)
             .build());
@@ -775,7 +776,7 @@ public class TodoInitializer implements ApplicationRunner {
             .description("주말 북한산 등산, 친구들과 오전 8시 출발")
             .priorityId(0)
             .category(categoryMap.getOrDefault("운동", categories.isEmpty() ? null : categories.getFirst()))
-            .dueDate(LocalDate.now().plusDays(3))
+            .dueDate(Instant.now().plus(3, ChronoUnit.DAYS))
             .tags(Set.of("등산", "아웃도어", "취미"))
             .member(member)
             .build());
@@ -785,7 +786,7 @@ public class TodoInitializer implements ApplicationRunner {
             .description("오후 6시, 자유형 기술 연습")
             .priorityId(1)
             .category(categoryMap.getOrDefault("운동", categories.isEmpty() ? null : categories.getFirst()))
-            .dueDate(LocalDate.now())
+            .dueDate(Instant.now())
             .tags(Set.of("수영", "강습", "기술"))
             .member(member)
             .build());
@@ -795,7 +796,7 @@ public class TodoInitializer implements ApplicationRunner {
             .description("오전 8시, 명상 중심 요가 수업")
             .priorityId(0)
             .category(categoryMap.getOrDefault("운동", categories.isEmpty() ? null : categories.getFirst()))
-            .dueDate(LocalDate.now().plusDays(1))
+            .dueDate(Instant.now().plus(1, ChronoUnit.DAYS))
             .tags(Set.of("요가", "명상", "스트레칭"))
             .member(member)
             .build());
@@ -805,7 +806,7 @@ public class TodoInitializer implements ApplicationRunner {
             .description("운동 효과 극대화를 위한 일주일 식단 계획")
             .priorityId(1)
             .category(categoryMap.getOrDefault("운동", categories.isEmpty() ? null : categories.getFirst()))
-            .dueDate(LocalDate.now().minusDays(3))
+            .dueDate(Instant.now().minus(3, ChronoUnit.DAYS))
             .tags(Set.of("식단", "영양", "건강"))
             .member(member)
             .build());
@@ -815,7 +816,7 @@ public class TodoInitializer implements ApplicationRunner {
             .description("포핸드 스트로크 연습, 오후 2시")
             .priorityId(0)
             .category(categoryMap.getOrDefault("운동", categories.isEmpty() ? null : categories.getFirst()))
-            .dueDate(LocalDate.now().plusDays(2))
+            .dueDate(Instant.now().plus(2, ChronoUnit.DAYS))
             .tags(Set.of("테니스", "레슨", "기술"))
             .member(member)
             .build());
@@ -825,7 +826,7 @@ public class TodoInitializer implements ApplicationRunner {
             .description("축구 동호회 가입 신청 및 첫 모임 참석")
             .priorityId(0)
             .category(categoryMap.getOrDefault("운동", categories.isEmpty() ? null : categories.getFirst()))
-            .dueDate(LocalDate.now().plusDays(3))
+            .dueDate(Instant.now().plus(3, ChronoUnit.DAYS))
             .tags(Set.of("축구", "동호회", "사교"))
             .member(member)
             .build());
@@ -835,7 +836,7 @@ public class TodoInitializer implements ApplicationRunner {
             .description("헬스장 인바디 측정 및 목표 설정")
             .priorityId(0)
             .category(categoryMap.getOrDefault("운동", categories.isEmpty() ? null : categories.getFirst()))
-            .dueDate(LocalDate.now().minusDays(1))
+            .dueDate(Instant.now().minus(1, ChronoUnit.DAYS))
             .tags(Set.of("인바디", "측정", "목표"))
             .member(member)
             .build());
@@ -845,7 +846,7 @@ public class TodoInitializer implements ApplicationRunner {
             .description("한강 자전거 코스 40km 계획 및 장비 점검")
             .priorityId(0)
             .category(categoryMap.getOrDefault("운동", categories.isEmpty() ? null : categories.getFirst()))
-            .dueDate(LocalDate.now())
+            .dueDate(Instant.now())
             .tags(Set.of("사이클링", "자전거", "한강"))
             .member(member)
             .build());
@@ -855,7 +856,7 @@ public class TodoInitializer implements ApplicationRunner {
             .description("전신 스트레칭 30분, 유연성 향상")
             .priorityId(0)
             .category(categoryMap.getOrDefault("운동", categories.isEmpty() ? null : categories.getFirst()))
-            .dueDate(LocalDate.now().plusDays(1))
+            .dueDate(Instant.now().plus(1, ChronoUnit.DAYS))
             .tags(Set.of("스트레칭", "유연성", "몸관리"))
             .member(member)
             .build());

--- a/src/main/java/point/zzicback/todo/domain/Todo.java
+++ b/src/main/java/point/zzicback/todo/domain/Todo.java
@@ -7,8 +7,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import point.zzicback.category.domain.Category;
 import point.zzicback.member.domain.Member;
 
-import java.time.LocalDate;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -37,7 +36,7 @@ public class Todo {
   @JoinColumn(name = "category_id")
   private Category category;
   
-  private LocalDate dueDate;
+  private Instant dueDate;
   
   @Enumerated(EnumType.ORDINAL)
   private RepeatType repeatType;
@@ -53,11 +52,11 @@ public class Todo {
 
   @CreatedDate
   @Column(updatable = false)
-  private LocalDateTime createdAt;
+  private Instant createdAt;
 
   @Builder
   public Todo(Long id, String title, String description, Integer statusId, Integer priorityId, 
-              Category category, LocalDate dueDate, RepeatType repeatType, 
+              Category category, Instant dueDate, RepeatType repeatType,
               Set<String> tags, Member member) {
     this.id = id;
     this.title = title;

--- a/src/main/java/point/zzicback/todo/domain/TodoRepository.java
+++ b/src/main/java/point/zzicback/todo/domain/TodoRepository.java
@@ -4,7 +4,7 @@ import org.springframework.data.domain.*;
 import org.springframework.data.jpa.repository.*;
 import org.springframework.data.repository.query.Param;
 
-import java.time.LocalDate;
+import java.time.Instant;
 import java.util.*;
 
 /**
@@ -15,17 +15,21 @@ public interface TodoRepository extends JpaRepository<Todo, Long> {
     @Query("""
         SELECT t FROM Todo t WHERE t.member.id = :memberId
         AND (:hideStatusIds IS NULL OR t.statusId NOT IN :hideStatusIds)
-        ORDER BY 
-          CASE t.statusId 
-            WHEN 2 THEN 0 
-            WHEN 0 THEN 1 
-            WHEN 1 THEN 2 
+        AND (:startDate IS NULL OR t.dueDate >= :startDate)
+        AND (:endDate IS NULL OR t.dueDate <= :endDate)
+        ORDER BY
+          CASE t.statusId
+            WHEN 2 THEN 0
+            WHEN 0 THEN 1
+            WHEN 1 THEN 2
             ELSE 3 END,
           t.dueDate ASC,
           t.createdAt ASC
         """)
     Page<Todo> findByMemberId(@Param("memberId") UUID memberId,
                              @Param("hideStatusIds") List<Integer> hideStatusIds,
+                             @Param("startDate") Instant startDate,
+                             @Param("endDate") Instant endDate,
                              Pageable pageable);
 
     Optional<Todo> findByIdAndMemberId(Long todoId, UUID memberId);
@@ -40,11 +44,13 @@ public interface TodoRepository extends JpaRepository<Todo, Long> {
              LOWER(t.description) LIKE LOWER(CONCAT('%', :keyword, '%')) OR
              LOWER(tag) LIKE LOWER(CONCAT('%', :keyword, '%')))
         AND (:hideStatusIds IS NULL OR t.statusId NOT IN :hideStatusIds)
-        ORDER BY 
-          CASE t.statusId 
-            WHEN 2 THEN 0 
-            WHEN 0 THEN 1 
-            WHEN 1 THEN 2 
+        AND (:startDate IS NULL OR t.dueDate >= :startDate)
+        AND (:endDate IS NULL OR t.dueDate <= :endDate)
+        ORDER BY
+          CASE t.statusId
+            WHEN 2 THEN 0
+            WHEN 0 THEN 1
+            WHEN 1 THEN 2
             ELSE 3 END,
           t.dueDate ASC,
           t.createdAt ASC
@@ -55,11 +61,13 @@ public interface TodoRepository extends JpaRepository<Todo, Long> {
                            @Param("priorityId") Integer priorityId,
                            @Param("keyword") String keyword,
                            @Param("hideStatusIds") List<Integer> hideStatusIds,
+                           @Param("startDate") Instant startDate,
+                           @Param("endDate") Instant endDate,
                            Pageable pageable);
 
     @Modifying
     @Query("UPDATE Todo t SET t.statusId = 2 WHERE t.statusId = 0 AND t.dueDate < :currentDate")
-    int updateOverdueTodos(@Param("currentDate") LocalDate currentDate);
+    int updateOverdueTodos(@Param("currentDate") Instant currentDate);
     
     @Query("SELECT COUNT(t) FROM Todo t WHERE t.member.id = :memberId")
     long countByMemberId(@Param("memberId") UUID memberId);
@@ -71,7 +79,7 @@ public interface TodoRepository extends JpaRepository<Todo, Long> {
     long countCompletedByMemberId(@Param("memberId") UUID memberId);
     
     @Query("SELECT COUNT(t) FROM Todo t WHERE t.member.id = :memberId AND (t.statusId = 2 OR (t.statusId = 0 AND t.dueDate < :currentDate))")
-    long countOverdueByMemberId(@Param("memberId") UUID memberId, @Param("currentDate") LocalDate currentDate);
+    long countOverdueByMemberId(@Param("memberId") UUID memberId, @Param("currentDate") Instant currentDate);
     
     @Query("SELECT DISTINCT tag FROM Todo t JOIN t.tags tag WHERE t.member.id = :memberId")
     Page<String> findDistinctTagsByMemberId(@Param("memberId") UUID memberId, Pageable pageable);

--- a/src/main/java/point/zzicback/todo/presentation/TodoController.java
+++ b/src/main/java/point/zzicback/todo/presentation/TodoController.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.media.*;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.*;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -14,6 +15,7 @@ import point.zzicback.todo.application.dto.query.*;
 import point.zzicback.todo.presentation.dto.*;
 import point.zzicback.todo.presentation.mapper.TodoPresentationMapper;
 
+import java.time.Instant;
 import java.util.List;
 
 @RestController
@@ -37,10 +39,26 @@ public class TodoController {
           @Parameter(description = "카테고리 ID 필터", example = "1")
           Long categoryId,
           @RequestParam(required = false)
-          @Parameter(description = "우선순위 필터 (0: 낮음, 1: 보통, 2: 높음)", 
+          @Parameter(description = "우선순위 필터 (0: 낮음, 1: 보통, 2: 높음)",
                      schema = @Schema(allowableValues = {"0", "1", "2"}),
                      example = "1")
           Integer priorityId,
+          @RequestParam(required = false)
+          @Parameter(
+              description = "검색 시작 시각",
+              example = "2024-01-01T00:00:00Z",
+              schema = @Schema(type = "string", format = "date-time")
+          )
+          @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+          Instant startDate,
+          @RequestParam(required = false)
+          @Parameter(
+              description = "검색 종료 시각",
+              example = "2024-01-31T23:59:59Z",
+              schema = @Schema(type = "string", format = "date-time")
+          )
+          @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+          Instant endDate,
           @RequestParam(required = false)
           @Parameter(description = "검색 키워드 (제목, 설명, 태그에서 검색)",
                      example = "영어")
@@ -51,7 +69,8 @@ public class TodoController {
           @RequestParam(defaultValue = "0") int page,
           @RequestParam(defaultValue = "10") int size) {
     Pageable pageable = PageRequest.of(page, size);
-    TodoListQuery query = TodoListQuery.of(principal.id(), statusId, categoryId, priorityId, keyword, hideStatusIds, pageable);
+    TodoListQuery query = TodoListQuery.of(principal.id(), statusId, categoryId,
+        priorityId, keyword, hideStatusIds, startDate, endDate, pageable);
     return todoService.getTodoList(query).map(todoPresentationMapper::toResponse);
   }
 
@@ -82,7 +101,7 @@ public class TodoController {
                         "status": "IN_PROGRESS",
                         "priority": 1,
                         "categoryId": 1,
-                        "dueDate": "2026-01-01",
+                        "dueDate": "2026-01-01T00:00:00Z",
                         "repeatType": "NONE",
                         "tags": ["영어", "학습"]
                       }
@@ -135,7 +154,7 @@ public class TodoController {
                         "statusId": 1,
                         "priorityId": 2,
                         "categoryId": 1,
-                        "dueDate": "2026-01-02",
+                        "dueDate": "2026-01-02T00:00:00Z",
                         "repeatType": "DAILY",
                         "tags": ["영어", "학습", "토익"]
                       }

--- a/src/main/java/point/zzicback/todo/presentation/dto/CreateTodoRequest.java
+++ b/src/main/java/point/zzicback/todo/presentation/dto/CreateTodoRequest.java
@@ -5,7 +5,7 @@ import jakarta.validation.constraints.*;
 import lombok.*;
 import point.zzicback.todo.domain.RepeatType;
 
-import java.time.LocalDate;
+import java.time.Instant;
 
 @Data
 @NoArgsConstructor
@@ -71,12 +71,11 @@ public class CreateTodoRequest {
     private Long categoryId;
 
     @Schema(
-        description = "마감일", 
-        example = "2026-01-01", 
-        format = "date",
-        pattern = "^\\d{4}-\\d{2}-\\d{2}$"
+        description = "마감 시각(UTC)",
+        example = "2026-01-01T00:00:00Z",
+        format = "date-time"
     )
-    private LocalDate dueDate;
+    private Instant dueDate;
     
     @Schema(
         description = "반복 유형", 

--- a/src/main/java/point/zzicback/todo/presentation/dto/TodoResponse.java
+++ b/src/main/java/point/zzicback/todo/presentation/dto/TodoResponse.java
@@ -3,7 +3,7 @@ package point.zzicback.todo.presentation.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import point.zzicback.todo.domain.RepeatType;
 
-import java.time.LocalDate;
+import java.time.Instant;
 import java.util.Set;
 
 @Schema(description = "Todo 응답 DTO")
@@ -35,8 +35,8 @@ public record TodoResponse(
         @Schema(description = "카테고리명", example = "학습")
         String categoryName,
         
-        @Schema(description = "마감일", example = "2024-12-31")
-        LocalDate dueDate,
+        @Schema(description = "마감 시각", example = "2024-12-31T23:59:59Z")
+        Instant dueDate,
         
         @Schema(description = "반복 유형", example = "DAILY")
         RepeatType repeatType,

--- a/src/main/java/point/zzicback/todo/presentation/dto/UpdateTodoRequest.java
+++ b/src/main/java/point/zzicback/todo/presentation/dto/UpdateTodoRequest.java
@@ -5,7 +5,7 @@ import jakarta.validation.constraints.Size;
 import lombok.*;
 import point.zzicback.todo.domain.RepeatType;
 
-import java.time.LocalDate;
+import java.time.Instant;
 
 @Data
 @NoArgsConstructor
@@ -67,12 +67,11 @@ public class UpdateTodoRequest {
     private Long categoryId;
 
     @Schema(
-        description = "마감일", 
-        example = "2026-01-01", 
-        format = "date",
-        pattern = "^\\d{4}-\\d{2}-\\d{2}$"
+        description = "마감 시각(UTC)",
+        example = "2026-01-01T00:00:00Z",
+        format = "date-time"
     )
-    private LocalDate dueDate;
+    private Instant dueDate;
     
     @Schema(
         description = "반복 유형", 


### PR DESCRIPTION
## Summary
- support startDate/endDate filters for todos
- include date parameters in TodoListQuery
- update TodoService logic for new filters
- extend TodoRepository queries for date range
- expose parameters on TodoController
- test date range filtering in TodoServiceTestNew
- convert todo date fields to Instant for UTC handling
- clarify Instant request docs with UTC format

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_6856d65b4ff8832d995e4ba6fb393c5c