### PR TITLE
Add leveling and experience domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,15 @@ src/
 │   │   ├── domain/              # 챌린지 도메인
 │   │   ├── infrastructure/      # 챌린지 데이터 저장소
 │   │   └── presentation/        # 챌린지 API
+│   ├── experience/              # 경험치 관리
+│   │   ├── application/         # 경험치 서비스
+│   │   ├── domain/              # 경험치 도메인
+│   │   └── infrastructure/      # 경험치 저장소
+│   ├── level/                   # 레벨 정의
+│   │   ├── application/         # 레벨 서비스
+│   │   ├── domain/              # 레벨 도메인
+│   │   ├── infrastructure/      # 레벨 저장소
+│   │   └── config/              # 초기화 설정
 │   └── common/                  # 공통 유틸리티
 │       ├── config/              # 공통 설정
 │       ├── error/               # 예외 처리

--- a/src/main/java/point/zzicback/experience/application/ExperienceService.java
+++ b/src/main/java/point/zzicback/experience/application/ExperienceService.java
@@ -1,0 +1,32 @@
+package point.zzicback.experience.application;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import point.zzicback.experience.domain.MemberExperience;
+import point.zzicback.experience.infrastructure.MemberExperienceRepository;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ExperienceService {
+    private final MemberExperienceRepository repository;
+
+    public void addExperience(UUID memberId, int amount) {
+        MemberExperience exp = repository.findByMemberId(memberId)
+                .orElseGet(() -> repository.save(MemberExperience.builder()
+                        .memberId(memberId)
+                        .experience(0)
+                        .build()));
+        exp.addExperience(amount);
+    }
+
+    @Transactional(readOnly = true)
+    public int getExperience(UUID memberId) {
+        return repository.findByMemberId(memberId)
+                .map(MemberExperience::getExperience)
+                .orElse(0);
+    }
+}

--- a/src/main/java/point/zzicback/experience/application/event/ExperienceEventHandler.java
+++ b/src/main/java/point/zzicback/experience/application/event/ExperienceEventHandler.java
@@ -1,0 +1,23 @@
+package point.zzicback.experience.application.event;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import point.zzicback.experience.domain.MemberExperience;
+import point.zzicback.experience.infrastructure.MemberExperienceRepository;
+import point.zzicback.member.application.event.MemberCreatedEvent;
+
+@Component
+@RequiredArgsConstructor
+public class ExperienceEventHandler {
+    private final MemberExperienceRepository repository;
+
+    @EventListener
+    public void handleMemberCreated(MemberCreatedEvent event) {
+        repository.findByMemberId(event.memberId())
+                .orElseGet(() -> repository.save(MemberExperience.builder()
+                        .memberId(event.memberId())
+                        .experience(0)
+                        .build()));
+    }
+}

--- a/src/main/java/point/zzicback/experience/domain/MemberExperience.java
+++ b/src/main/java/point/zzicback/experience/domain/MemberExperience.java
@@ -1,0 +1,32 @@
+package point.zzicback.experience.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.UUID;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "member_experiences")
+public class MemberExperience {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private UUID memberId;
+
+    @Column(nullable = false)
+    private int experience;
+
+    @Builder
+    public MemberExperience(UUID memberId, int experience) {
+        this.memberId = memberId;
+        this.experience = experience;
+    }
+
+    public void addExperience(int amount) {
+        this.experience += amount;
+    }
+}

--- a/src/main/java/point/zzicback/experience/infrastructure/MemberExperienceRepository.java
+++ b/src/main/java/point/zzicback/experience/infrastructure/MemberExperienceRepository.java
@@ -1,0 +1,11 @@
+package point.zzicback.experience.infrastructure;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import point.zzicback.experience.domain.MemberExperience;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface MemberExperienceRepository extends JpaRepository<MemberExperience, Long> {
+    Optional<MemberExperience> findByMemberId(UUID memberId);
+}

--- a/src/main/java/point/zzicback/level/application/LevelService.java
+++ b/src/main/java/point/zzicback/level/application/LevelService.java
@@ -1,0 +1,21 @@
+package point.zzicback.level.application;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import point.zzicback.level.domain.Level;
+import point.zzicback.level.infrastructure.LevelRepository;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class LevelService {
+    private final LevelRepository levelRepository;
+
+    public Level getLevelByExperience(int experience) {
+        return levelRepository.findAll().stream()
+                .filter(l -> experience >= l.getRequiredExp())
+                .max(java.util.Comparator.comparingInt(Level::getRequiredExp))
+                .orElse(null);
+    }
+}

--- a/src/main/java/point/zzicback/level/config/LevelInitializer.java
+++ b/src/main/java/point/zzicback/level/config/LevelInitializer.java
@@ -1,0 +1,50 @@
+package point.zzicback.level.config;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+import point.zzicback.level.domain.Level;
+import point.zzicback.level.infrastructure.LevelRepository;
+
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class LevelInitializer implements ApplicationRunner {
+    private final LevelRepository levelRepository;
+
+    @Override
+    public void run(ApplicationArguments args) {
+        if (levelRepository.count() > 0) {
+            log.info("Levels already initialized");
+            return;
+        }
+        List<Level> levels = List.of(
+                new Level(1, "찍찍 초심자", 0),
+                new Level(2, "나도 J?", 100),
+                new Level(3, "혹시 내가 J?", 250),
+                new Level(4, "작심삼일 브레이커", 450),
+                new Level(5, "나무늘보", 700),
+                new Level(6, "미라클모닝러", 1000),
+                new Level(7, "밤샘요정", 1350),
+                new Level(8, "약속지키미", 1750),
+                new Level(9, "꾸준찍찍이", 2200),
+                new Level(10, "파워J", 2700),
+                new Level(11, "찍찍 숙련자", 3250),
+                new Level(12, "도전러", 3850),
+                new Level(13, "극한 찍찍이", 4500),
+                new Level(14, "꾸준왕", 5200),
+                new Level(15, "헬다이브 준비생", 5950),
+                new Level(16, "헬다이브 베테랑", 6750),
+                new Level(17, "헬다이브 마스터", 7600),
+                new Level(18, "지옥의 사령관", 8500),
+                new Level(19, "찍찍 챌린저", 9450),
+                new Level(20, "찍찍 레전드", 10450)
+        );
+        levelRepository.saveAll(levels);
+        log.info("Initialized {} levels", levels.size());
+    }
+}

--- a/src/main/java/point/zzicback/level/domain/Level.java
+++ b/src/main/java/point/zzicback/level/domain/Level.java
@@ -1,0 +1,26 @@
+package point.zzicback.level.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "levels")
+public class Level {
+    @Id
+    private Integer level;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private int requiredExp;
+
+    @Builder
+    public Level(Integer level, String name, int requiredExp) {
+        this.level = level;
+        this.name = name;
+        this.requiredExp = requiredExp;
+    }
+}

--- a/src/main/java/point/zzicback/level/infrastructure/LevelRepository.java
+++ b/src/main/java/point/zzicback/level/infrastructure/LevelRepository.java
@@ -1,0 +1,7 @@
+package point.zzicback.level.infrastructure;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import point.zzicback.level.domain.Level;
+
+public interface LevelRepository extends JpaRepository<Level, Integer> {
+}


### PR DESCRIPTION
## Summary
- add domains for member experience and level definitions
- seed 20 fun level names via LevelInitializer
- document new modules in README

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_6856fc6efe1c832dacda400d84d3bf5d