### PR TITLE
Handle tags as repeated parameters

### DIFF
--- a/src/main/java/point/zzicback/todo/presentation/dto/CreateTodoRequest.java
+++ b/src/main/java/point/zzicback/todo/presentation/dto/CreateTodoRequest.java
@@ -22,7 +22,7 @@ import java.util.*;
           "categoryId": 1,
           "dueDate": "2026-01-01T00:00:00Z",
           "repeatType": "NONE",
-          "tags": "영어,학습"
+          "tags": ["영어", "학습"]
         }
         """
 )
@@ -116,9 +116,9 @@ public class CreateTodoRequest {
     private LocalDate repeatEndDate;
     
     @Schema(
-        description = "태그 목록 (콤마로 구분)", 
-        example = "영어,학습",
-        type = "string"
+        description = "태그 목록. 같은 이름으로 여러 번 전달합니다.",
+        example = "tags=영어&tags=학습",
+        type = "array"
     )
-    private String tags;
+    private Set<String> tags;
 }

--- a/src/main/java/point/zzicback/todo/presentation/dto/UpdateTodoRequest.java
+++ b/src/main/java/point/zzicback/todo/presentation/dto/UpdateTodoRequest.java
@@ -22,7 +22,7 @@ import java.util.*;
           "categoryId": 1,
           "dueDate": "2026-01-02T00:00:00Z",
           "repeatType": "DAILY",
-          "tags": "영어,학습,토익"
+          "tags": ["영어", "학습", "토익"]
         }
         """
 )
@@ -107,9 +107,9 @@ public class UpdateTodoRequest {
     private LocalDate repeatEndDate;
     
     @Schema(
-        description = "태그 목록 (콤마로 구분)", 
-        example = "영어,학습,토익",
-        type = "string"
+        description = "태그 목록. 같은 이름으로 여러 번 전달합니다.",
+        example = "tags=영어&tags=학습&tags=토익",
+        type = "array"
     )
-    private String tags;
+    private Set<String> tags;
 }

--- a/src/main/java/point/zzicback/todo/presentation/mapper/TodoPresentationMapper.java
+++ b/src/main/java/point/zzicback/todo/presentation/mapper/TodoPresentationMapper.java
@@ -9,18 +9,18 @@ import point.zzicback.todo.presentation.dto.*;
 
 import java.util.*;
 
-@Mapper(componentModel = "spring", imports = {Arrays.class, java.util.stream.Collectors.class, PageRequest.class})
+@Mapper(componentModel = "spring", imports = {PageRequest.class})
 public interface TodoPresentationMapper {
   @Mapping(target = "memberId", source = "memberId")
   @Mapping(target = "priorityId", source = "request.priorityId")
-  @Mapping(target = "tags", expression = "java(parseTagsString(request.getTags()))")
+  @Mapping(target = "tags", source = "request.tags")
   CreateTodoCommand toCommand(CreateTodoRequest request, UUID memberId);
 
   @Mapping(target = "memberId", source = "memberId")
   @Mapping(target = "todoId", source = "todoId")
   @Mapping(target = "statusId", source = "request.statusId")
   @Mapping(target = "priorityId", source = "request.priorityId")
-  @Mapping(target = "tags", expression = "java(parseTagsString(request.getTags()))")
+  @Mapping(target = "tags", source = "request.tags")
   @Mapping(target = "originalTodoId", ignore = true)
   UpdateTodoCommand toCommand(UpdateTodoRequest request, UUID memberId, Long todoId);
 
@@ -31,16 +31,6 @@ public interface TodoPresentationMapper {
   point.zzicback.todo.presentation.dto.TodoResponse toResponse(TodoResult todoResult);
   
   CalendarTodoStatusResponse toCalendarResponse(CalendarTodoStatus status);
-
-  default Set<String> parseTagsString(String tagsString) {
-    if (tagsString == null || tagsString.trim().isEmpty()) {
-      return null;
-    }
-    return Arrays.stream(tagsString.split(","))
-        .map(String::trim)
-        .filter(tag -> !tag.isEmpty())
-        .collect(java.util.stream.Collectors.toSet());
-  }
   
   default TodoStatisticsResponse toStatisticsResponse(TodoStatistics statistics) {
     List<TodoStatisticsResponse.StatisticsItem> content = List.of(


### PR DESCRIPTION
## Summary
- allow multi-value tags in `CreateTodoRequest` and `UpdateTodoRequest`
- update `TodoPresentationMapper` accordingly

## Testing
- `./gradlew test` *(fails: 1 test)*

------
https://chatgpt.com/codex/tasks/task_e_6860ad9a1ce0832dbe5fcd203334b7be