### PR TITLE
Implement virtual todo retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ docker-compose -f docker-compose.local.yml down -v
 |-------------|----------|------|-----------|-----------|-----------|
 | **GET** | `/api/members/{memberId}/todos` | TODO 목록 조회 (페이징) | 없음 | `Page<TodoResponse>` | `200`: 성공 |
 | **GET** | `/api/members/{memberId}/todos/{id}` | 특정 TODO 조회 | 없음 | `TodoResponse` | `200`: 성공<br>`404`: 찾을 수 없음 |
+| **GET** | `/api/members/{memberId}/todos/{id}:{diff}` | 반복 TODO 가상 인스턴스 조회 | 없음 | `TodoResponse` | `200`: 성공<br>`404`: 찾을 수 없음 |
 | **POST** | `/api/members/{memberId}/todos` | TODO 생성 | `CreateTodoRequest` | 없음 | `201`: 성공<br>`400`: 잘못된 요청 |
 | **PUT** | `/api/members/{memberId}/todos/{id}` | TODO 전체 수정 | `UpdateTodoRequest` | 없음 | `204`: 성공<br>`400`: 잘못된 요청<br>`404`: 찾을 수 없음 |
 | **PATCH** | `/api/members/{memberId}/todos/{id}` | TODO 부분 수정 | `UpdateTodoRequest` | 없음 | `204`: 성공<br>`400`: 잘못된 요청<br>`404`: 찾을 수 없음 |

--- a/src/main/java/point/zzicback/todo/application/dto/query/VirtualTodoQuery.java
+++ b/src/main/java/point/zzicback/todo/application/dto/query/VirtualTodoQuery.java
@@ -1,0 +1,9 @@
+package point.zzicback.todo.application.dto.query;
+
+import java.util.UUID;
+
+public record VirtualTodoQuery(UUID memberId, Long originalTodoId, Long daysDifference) {
+    public static VirtualTodoQuery of(UUID memberId, Long originalTodoId, Long daysDifference) {
+        return new VirtualTodoQuery(memberId, originalTodoId, daysDifference);
+    }
+}

--- a/src/main/java/point/zzicback/todo/presentation/TodoController.java
+++ b/src/main/java/point/zzicback/todo/presentation/TodoController.java
@@ -44,6 +44,19 @@ public class TodoController {
     return todoPresentationMapper.toResponse(todoService.getTodo(TodoQuery.of(principal.id(), id)));
   }
 
+  @GetMapping("/{patternId:\\d+}:{daysDifference:\\d+}")
+  @ResponseStatus(HttpStatus.OK)
+  @Operation(summary = "가상 Todo 조회", description = "반복 Todo의 특정 가상 인스턴스를 조회합니다.")
+  public TodoResponse getVirtualTodo(@AuthenticationPrincipal MemberPrincipal principal,
+                                     @PathVariable Long patternId,
+                                     @PathVariable Long daysDifference) {
+    return todoPresentationMapper.toResponse(
+        todoService.getVirtualTodo(
+            VirtualTodoQuery.of(principal.id(), patternId, daysDifference)
+        )
+    );
+  }
+
   @PostMapping(
     consumes = { MediaType.APPLICATION_FORM_URLENCODED_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE }
   )


### PR DESCRIPTION
## Summary
- add `VirtualTodoQuery` for fetching virtual todos
- support retrieving virtual todos in `TodoService`
- expose new `/todos/{patternId}:{daysDifference}` endpoint
- document the virtual todo GET endpoint

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68614e8c0dac832d9d677acaec55527f