### PR TITLE
Simplify member experience endpoint

### DIFF
--- a/src/main/java/point/zzicback/experience/presentation/ExperienceController.java
+++ b/src/main/java/point/zzicback/experience/presentation/ExperienceController.java
@@ -4,27 +4,27 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-import point.zzicback.auth.domain.MemberPrincipal;
 import point.zzicback.experience.application.ExperienceService;
 import point.zzicback.experience.presentation.dto.response.MemberLevelResponse;
 import point.zzicback.experience.presentation.mapper.ExperiencePresentationMapper;
 
+import java.util.UUID;
+
 @Tag(name = "경험치", description = "경험치 및 레벨 관련 API")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/experience")
+@RequestMapping("/members")
 public class ExperienceController {
     
     private final ExperienceService experienceService;
     private final ExperiencePresentationMapper mapper;
 
-    @Operation(summary = "내 레벨/경험치 조회", description = "현재 사용자의 레벨과 경험치 정보를 조회합니다.")
+    @Operation(summary = "회원 레벨/경험치 조회", description = "특정 회원의 레벨과 경험치를 조회합니다.")
     @ApiResponse(responseCode = "200", description = "레벨/경험치 조회 성공")
-    @GetMapping("/me")
-    public MemberLevelResponse getMyLevel(@AuthenticationPrincipal MemberPrincipal principal) {
-        var result = experienceService.getMemberLevel(principal.id());
+    @GetMapping("/{memberId}/experience")
+    public MemberLevelResponse getMemberLevel(@PathVariable UUID memberId) {
+        var result = experienceService.getMemberLevel(memberId);
         return mapper.toResponse(result);
     }
 }

--- a/src/test/java/point/zzicback/experience/application/ExperienceServiceTest.java
+++ b/src/test/java/point/zzicback/experience/application/ExperienceServiceTest.java
@@ -1,0 +1,59 @@
+package point.zzicback.experience.application;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import point.zzicback.experience.domain.MemberExperience;
+import point.zzicback.experience.infrastructure.MemberExperienceRepository;
+import point.zzicback.level.application.LevelService;
+import point.zzicback.level.domain.Level;
+import point.zzicback.level.infrastructure.LevelRepository;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import({ExperienceService.class, LevelService.class})
+class ExperienceServiceTest {
+
+    @Autowired
+    private ExperienceService experienceService;
+    @Autowired
+    private MemberExperienceRepository memberExperienceRepository;
+    @Autowired
+    private LevelRepository levelRepository;
+
+    private UUID memberId;
+
+    @BeforeEach
+    void setUp() {
+        levelRepository.save(new Level(1, "Lv1", 0));
+        levelRepository.save(new Level(2, "Lv2", 10));
+        levelRepository.save(new Level(3, "Lv3", 30));
+
+        memberId = UUID.randomUUID();
+        memberExperienceRepository.save(
+                MemberExperience.builder()
+                        .memberId(memberId)
+                        .experience(15)
+                        .build()
+        );
+    }
+
+    @Test
+    @DisplayName("회원 경험치 레벨 계산")
+    void getMemberLevel() {
+        var result = experienceService.getMemberLevel(memberId);
+
+        assertThat(result.currentLevel()).isEqualTo(2);
+        assertThat(result.currentExp()).isEqualTo(15);
+        assertThat(result.currentLevelMinExp()).isEqualTo(10);
+        assertThat(result.currentLevelProgress()).isEqualTo(5);
+        assertThat(result.currentLevelTotal()).isEqualTo(20);
+        assertThat(result.expToNextLevel()).isEqualTo(15);
+    }
+}


### PR DESCRIPTION
## Summary
- remove principal-based experience method
- keep member experience lookup at `/members/{memberId}/experience`

## Testing
- `./gradlew test --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_686265622398832d92e1c9e029bbba9e